### PR TITLE
Add support for string in eip712

### DIFF
--- a/src/utils/encoding/calldata.ts
+++ b/src/utils/encoding/calldata.ts
@@ -1,4 +1,5 @@
 import { Choice } from '../choice';
+import { IntsSequence } from '../ints-sequence';
 
 /**
  * Currently there is no way to pass struct types with pointers in calldata, so we must pass the 2d array as a flat array and then reconstruct the type.
@@ -36,7 +37,7 @@ export function flatten2DArray(array2D: bigint[][]): bigint[] {
  */
 export function getProposeCalldata(
   proposerAddress: string,
-  metadataUri: bigint[],
+  metadataUri: IntsSequence,
   executorAddress: bigint,
   usedVotingStrategies: bigint[],
   usedVotingStrategyParams: bigint[][],
@@ -45,8 +46,9 @@ export function getProposeCalldata(
   const usedVotingStrategyParamsFlat = flatten2DArray(usedVotingStrategyParams);
   return [
     BigInt(proposerAddress),
-    BigInt(metadataUri.length),
-    ...metadataUri,
+    BigInt(metadataUri.bytesLength),
+    BigInt(metadataUri.values.length),
+    ...metadataUri.values,
     executorAddress,
     BigInt(usedVotingStrategies.length),
     ...usedVotingStrategies,

--- a/src/utils/ints-sequence.ts
+++ b/src/utils/ints-sequence.ts
@@ -26,6 +26,16 @@ export class IntsSequence {
     return SplitUint256.fromUint(uint);
   }
 
+  static LEFromString(str: string): IntsSequence {
+    const ints_array: bigint[] = [];
+    for (let i = 0; i < str.length; i += 8) {
+      let bytes = Buffer.from(str.slice(i, i + 8));
+      let leBytes = bytes.reverse();
+      ints_array.push(BigInt(bytesToHex(leBytes)));
+    }
+    return new IntsSequence(ints_array, str.length);
+  }
+
   static fromBytes(bytes: number[]): IntsSequence {
     const ints_array: bigint[] = [];
     for (let i = 0; i < bytes.length; i += 8) {


### PR DESCRIPTION
- Update `getProposeCalldata`
- Add `LEFromString` which creates an `IntsSequence` in `LE` from a `string` (e.g `0x112233445566778899` -> `[0x8877665544332211, 0x99]`