### PR TITLE
feat: use latest deployment contracts

### DIFF
--- a/src/clients/starknet-tx/constants.json
+++ b/src/clients/starknet-tx/constants.json
@@ -1,6 +1,11 @@
 {
-  "auth": "0x1574bf879d7f62ce07d40eee018ed471613637ba1c7c9231363fa2b75cd386f",
-  "executor": "0x56aabaa21efea14289fdc1df7d76d3b5df179d94dc8e9f937b9a9dd75eb101a",
-  "strategy": "0x184f7df02cfeef5307c93a602206ff8708560cb20b185226be93089f2740f36",
-  "space": "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3"
+  "authenticators": {
+    "vanilla": "0x6ad07205a4d725c5c2b10c4f5fbdfaaa351c742fce7a5a22b2b56fd8d5afd62",
+    "ethSig": "0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643"
+  },
+  "strategies": {
+    "vanilla": "0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865",
+    "singleSlotProof": "0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6"
+  },
+  "executor": "0x7402b474327a0d7a2d5c3e01489386113d9654eaff8591344577458074bb1b7"
 }

--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -19,7 +19,7 @@ export class StarkNetTx {
     space: string,
     metadataUri: string
   ): Promise<AddTransactionResponse> {
-    const auth = new Contract(abi as Abi, constants.auth, provider);
+    const auth = new Contract(abi as Abi, constants.authenticators.vanilla, provider);
     auth.connect(account);
 
     const metadataUriInts = utils.intsSequence.IntsSequence.LEFromString(metadataUri);
@@ -27,7 +27,7 @@ export class StarkNetTx {
       author,
       metadataUriInts,
       constants.executor,
-      [constants.strategy],
+      [constants.strategies.vanilla],
       [[]],
       []
     );
@@ -50,14 +50,14 @@ export class StarkNetTx {
     proposal: string,
     choice: string
   ): Promise<AddTransactionResponse> {
-    const auth = new Contract(abi as Abi, constants.auth, provider);
+    const auth = new Contract(abi as Abi, constants.authenticators.vanilla, provider);
     auth.connect(account);
 
     const calldata = utils.encoding.getVoteCalldata(
       voter,
       proposal,
       Number(choice),
-      [constants.strategy],
+      [constants.strategies.vanilla],
       [[]]
     );
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,9 +3,18 @@ import { Account, defaultProvider, ec } from 'starknet';
 import { Wallet } from '@ethersproject/wallet';
 
 describe('', () => {
+  // Factory: 0x3e5165026e6586cd2d5cdf1fdced8af866f900e430bf1dc7b839c84604c506e
+  // Spaces
+  // [vanilla auth, vanilla voting strategy]
+  // 0x03ddbcdfec756eb9e9e0fbce7a90721570a09fc97d31a15b8e40769b93ecb957
+  // [ethSig auth, vanilla voting strategy]
+  // 0x03a48d8a7e80b7b295ef15efc4e1604e78b1f4460266cd460b6eb8826846bba0
+  // [ethSig auth, single slot proof (WETH goerli)]
+  // 0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8
+
   const wallet = Wallet.createRandom();
   const walletAddress = wallet.address;
-  const space = '0x5ad4bd1ca422953ac845ac7915ddfa93fe3fecec0ed8c86db5e294b0e18c9bd';
+  const space = '0x03ddbcdfec756eb9e9e0fbce7a90721570a09fc97d31a15b8e40769b93ecb957';
   const client = new StarkNetTx();
   const address = '0x00c26a3cdcc570da83f3dd6afd0db9d038ee096e2c56707d6348db3b06223427';
   const privKey = '0x78a61bf2d838b1094705168bbd5b462e665a5ce094d8b1c2e5438c66eeb9f59';
@@ -26,7 +35,7 @@ describe('', () => {
 
   it('StarkNetTx.vote()', async () => {
     const voter = walletAddress;
-    const proposal = '3';
+    const proposal = '1';
     const choice = '1';
 
     const receipt = await client.vote(account, voter, space, proposal, choice);


### PR DESCRIPTION
This PR switches to use latest deployment of spaces, with different types of auth/strategy combos set in config so it's easier to switch to particular one.