### PR TITLE
Add fromString and asStrings

### DIFF
--- a/src/clients/starknet-sig/types.ts
+++ b/src/clients/starknet-sig/types.ts
@@ -1,16 +1,21 @@
 export const domain = {
   name: 'snapshot-x',
   version: '1',
+  chainId: '0x534e5f474f45524c49', // SN_GOERLI
 };
 
 export const domainTypes = {
   StarkNetDomain: [
     {
       name: 'name',
-      type: 'felt',
+      type: 'string',
     },
     {
       name: 'version',
+      type: 'felt',
+    },
+    {
+      name: 'chainId',
       type: 'felt',
     },
   ],

--- a/src/clients/starknet-sig/types.ts
+++ b/src/clients/starknet-sig/types.ts
@@ -1,52 +1,65 @@
 export const domain = {
   name: 'snapshot-x',
   version: '1',
-  chainId: 1
 };
 
 export const domainTypes = {
   StarkNetDomain: [
     {
       name: 'name',
-      type: 'felt'
+      type: 'felt',
     },
     {
       name: 'version',
-      type: 'felt'
+      type: 'felt',
     },
-    {
-      name: 'chainId',
-      type: 'felt'
-    }
-  ]
+  ],
 };
 
 export const proposeTypes = {
   StarkNetDomain: domainTypes.StarkNetDomain,
   Propose: [
     { name: 'space', type: 'felt' },
-    { name: 'executionHash', type: 'felt' },
-    { name: 'metadataURI', type: 'felt' }
-  ]
+    { name: 'proposerAddress', type: 'felt' },
+    { name: 'metadataURI', type: 'felt*' },
+    { name: 'executor', type: 'felt' },
+    { name: 'executionParamsHash', type: 'felt' },
+    { name: 'usedVotingStrategiesHash', type: 'felt' },
+    { name: 'userVotingStrategyParamsFlatHash', type: 'felt' },
+    { name: 'salt', type: 'felt' },
+  ],
 };
 
 export const voteTypes = {
   StarkNetDomain: domainTypes.StarkNetDomain,
   Vote: [
     { name: 'space', type: 'felt' },
+    { name: 'voterAddress', type: 'felt' },
     { name: 'proposal', type: 'felt' },
-    { name: 'choice', type: 'felt' }
-  ]
+    { name: 'choice', type: 'felt' },
+    { name: 'usedVotingStrategiesHash', type: 'felt' },
+    { name: 'userVotingStrategyParamsFlatHash', type: 'felt' },
+    { name: 'salt', type: 'felt' },
+  ],
 };
 
 export interface Propose {
   space: string;
-  executionHash: string;
-  metadataURI: string;
+  proposerAddress: string;
+  metadataURI: string[];
+  executor: string;
+  executionParamsHash: string;
+  usedVotingStrategiesHash: string;
+  userVotingStrategyParamsFlatHash: string;
+  salt: string;
 }
 
 export interface Vote {
   space: string;
-  proposal: number;
+  voterAddress: string;
+  proposal: string;
   choice: number;
+  usedVotingStrategiesHash: string;
+  userVotingStrategyParamsFlatHash: string;
+  salt: string;
 }

--- a/src/utils/ints-sequence.ts
+++ b/src/utils/ints-sequence.ts
@@ -26,12 +26,31 @@ export class IntsSequence {
     return SplitUint256.fromUint(uint);
   }
 
+  asStrings(): string[] {
+    return this.values.map(s => {
+      let str = '';
+      for (let n = 2; n < s.length; n += 2) {
+        str += String.fromCharCode(parseInt(s.substring(n, n + 2), 16));
+      }
+      return str
+    })
+  }
+
   static LEFromString(str: string): IntsSequence {
     const intsArray: string[] = [];
     for (let i = 0; i < str.length; i += 8) {
       const bytes = Buffer.from(str.slice(i, i + 8));
       const leBytes = bytes.reverse();
       intsArray.push(bytesToHex(leBytes));
+    }
+    return new IntsSequence(intsArray, str.length);
+  }
+
+  static fromString(str: string): IntsSequence {
+    const intsArray: string[] = [];
+    for (let i = 0; i < str.length; i += 8) {
+      const bytes = Buffer.from(str.slice(i, i + 8));
+      intsArray.push(bytesToHex(bytes));
     }
     return new IntsSequence(intsArray, str.length);
   }


### PR DESCRIPTION
Adds the `IntsSequence.fromString` and `.asString()` methods.

This PR also updates the `starknet-sig` types :)

Previously there was only `LEFromString`, which returned bytes in little endian instead of BE