### PR TITLE
test: set extraGlobals to speedup jest Math

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   roots: ['<rootDir>/test'],
   setupFiles: ['<rootDir>/test/setup.ts'],
+  extraGlobals: ['Math'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -48,7 +48,7 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 300e3);
+    }, 60e3);
 
     it('StarkNetTx.vote()', async () => {
       const envelope = {
@@ -71,7 +71,7 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 300e3);
+    }, 60e3);
   });
 
   describe('ethSig authenticator', () => {
@@ -96,7 +96,7 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 300e3);
+    }, 60e3);
 
     it('StarkNetTx.vote()', async () => {
       const envelope = await ethSigClient.vote(wallet, walletAddress, {
@@ -113,7 +113,7 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 300e3);
+    }, 60e3);
   });
 
   describe('ethSig authenticator + single slot proof', () => {
@@ -161,7 +161,7 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 420e3);
+    }, 60e3);
 
     it('StarkNetTx.vote()', async () => {
       const envelope = await ethSigClient.vote(wallet, walletAddress, {
@@ -178,6 +178,6 @@ describe('StarkNetTx', () => {
       // await defaultProvider.waitForTransaction(receipt.transaction_hash);
 
       expect(receipt.code).toBe('TRANSACTION_RECEIVED');
-    }, 420e3);
+    }, 60e3);
   });
 });


### PR DESCRIPTION
Closes #71 

Configure [`extraGlobals`](https://jestjs.io/docs/configuration#sandboxinjectedglobals-arraystring)

## Test plan
- Run test of your choice.
- It should run faster than it used to be (was able to lower timeouts to 60s, and that should have headroom anyway).