### PR TITLE
test: separete unit and integration tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": [
-    "plugin:@typescript-eslint/recommended"
-  ],
-  "plugins": [
-    "prettier",
-    "@typescript-eslint"
-  ],
+  "extends": ["plugin:@typescript-eslint/recommended"],
+  "plugins": ["prettier", "@typescript-eslint"],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
@@ -18,5 +13,13 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-explicit-any": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  roots: ['<rootDir>/test'],
-  setupFiles: ['<rootDir>/test/setup.ts'],
-  extraGlobals: ['Math'],
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest'
-  },
-  testRegex: '/test(/(integration|unit))?/.*\\.test\\.ts$'
-};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint ./src ./test --ext .ts --fix",
     "prepare": "yarn build",
     "prepublishOnly": "yarn run lint",
-    "test": "jest"
+    "test": "jest -c test/jest.config.unit.js",
+    "test:integration": "jest -c test/jest.config.integration.js"
   },
   "dependencies": {
     "@ethereumjs/block": "^3.6.3",

--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -130,7 +130,7 @@ export class StarkNetTx {
     const singleSlotProofs = await this.getSingleSlotProofs(envelope, metadata);
 
     return singleSlotProofs.map((proof) => {
-      const proofInputs = utils.storageProofs.getProofInputs(TEMP_CONSTANTS.block, proof);
+      const proofInputs = utils.storageProofs.getProofInputs(metadata.block, proof);
 
       return {
         contractAddress: constants.fossilFactRegistryAddress,

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -1,4 +1,4 @@
-import { StarkNetTx, EthereumSig } from '../src/clients';
+import { StarkNetTx, EthereumSig } from '../../src/clients';
 import { Account, defaultProvider, ec } from 'starknet';
 import { Wallet } from '@ethersproject/wallet';
 
@@ -128,23 +128,6 @@ describe('StarkNetTx', () => {
     const space = '0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8';
     const authenticator = '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643';
     const strategy = '0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6';
-
-    it('StarkNetTx.getAccountProveCalls()', async () => {
-      const envelope = await ethSigClient.propose(wallet, walletAddress, {
-        space,
-        authenticator,
-        strategies: [strategy],
-        metadataURI: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca',
-        executionParams: []
-      });
-
-      const calls = await client.getProveAccountCalls(envelope, {
-        strategyParams: ['0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', '0x3'],
-        block: 7529615
-      });
-
-      expect(calls).toMatchSnapshot();
-    });
 
     it('StarkNetTx.propose()', async () => {
       const envelope = await ethSigClient.propose(wallet, walletAddress, {

--- a/test/jest.config.base.js
+++ b/test/jest.config.base.js
@@ -1,0 +1,7 @@
+module.exports = {
+  setupFiles: ['<rootDir>/setup.ts'],
+  extraGlobals: ['Math'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/test/jest.config.integration.js
+++ b/test/jest.config.integration.js
@@ -1,0 +1,6 @@
+const baseConfig = require('./jest.config.base');
+
+module.exports = {
+  ...baseConfig,
+  roots: ['<rootDir>/integration']
+};

--- a/test/jest.config.unit.js
+++ b/test/jest.config.unit.js
@@ -1,0 +1,6 @@
+const baseConfig = require('./jest.config.base');
+
+module.exports = {
+  ...baseConfig,
+  roots: ['<rootDir>/unit']
+};

--- a/test/unit/clients/starknet-tx/__snapshots__/index.test.ts.snap
+++ b/test/unit/clients/starknet-tx/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StarkNetTx ethSig authenticator + single slot proof StarkNetTx.getAccountProveCalls() 1`] = `
+exports[`StarkNetTx getAccountProveCalls should return single slot proof prove calls 1`] = `
 Array [
   Object {
     "calldata": Array [

--- a/test/unit/clients/starknet-tx/index.test.ts
+++ b/test/unit/clients/starknet-tx/index.test.ts
@@ -1,0 +1,44 @@
+import { StarkNetTx } from '../../../../src/clients';
+
+describe('StarkNetTx', () => {
+  const ethUrl = process.env.GOERLI_NODE_URL as string;
+  const client = new StarkNetTx({ ethUrl });
+
+  expect(ethUrl).toBeDefined();
+
+  describe('getAccountProveCalls', () => {
+    it('should return single slot proof prove calls', async () => {
+      const envelope = {
+        address: '0x0BF8dE8Fc51002c9fE7cb29352dcaCb757d0364b',
+        sig: '0x9477b6bae1534ea017fc44d8df019dcd74c87146c9ec0e37400019d3b5e7330010f89f8c80474f42f7d9a125156e8dc26a24d54eb1b496f88f04c467a9574f211c',
+        data: {
+          domain: { name: 'snapshot-x', version: '1' },
+          types: {
+            Propose: [
+              { name: 'space', type: 'bytes32' },
+              { name: 'executionHash', type: 'bytes32' },
+              { name: 'metadataURI', type: 'string' },
+              { name: 'salt', type: 'uint256' }
+            ]
+          },
+          message: {
+            space: '0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8',
+            authenticator: '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643',
+            strategies: ['0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6'],
+            metadataURI: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca',
+            executionParams: [],
+            executionHash: '0x049ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804',
+            salt: 2817056238
+          }
+        }
+      };
+
+      const calls = await client.getProveAccountCalls(envelope, {
+        strategyParams: ['0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', '0x3'],
+        block: 7529615
+      });
+
+      expect(calls).toMatchSnapshot();
+    });
+  });
+});

--- a/test/unit/utils/starkkey.test.ts
+++ b/test/unit/utils/starkkey.test.ts
@@ -1,9 +1,9 @@
 import { Account, ec, defaultProvider } from 'starknet';
 import { getStarkKey } from 'starknet/utils/ellipticCurve';
-import { verify } from '../src/utils/starkkey';
-import { domain, voteTypes } from '../src/clients/starknet-sig/types';
+import { verify } from '../../../src/utils/starkkey';
+import { domain, voteTypes } from '../../../src/clients/starknet-sig/types';
 
-describe('', () => {
+describe('starkkey', () => {
   let starkKeyPair = ec.genKeyPair();
   const privKey = starkKeyPair.getPrivate('hex');
   starkKeyPair = ec.getKeyPair(`0x${privKey}`);


### PR DESCRIPTION
Split tests into `unit` and `integration` tests.
This way we can run easy to test code automatically, and stuff that isn't fully automated yet (new proposals on the network) can still be executed manually.

In the future PR I will update Github to run unit tests in CI. (we will need to have `GOERLI_NODE_URL` added as a secret).

## Test plan
- Run `GOERLI_NODE_URL="XXX" yarn test` 
- Run `GOERLI_NODE_URL="XXX" ETH_PK="YYY" yarn test:integration` with your test selected by `.only`.