### PR TITLE
refactor: make authenticators pluggable

### DIFF
--- a/src/authenticators/ethSig.ts
+++ b/src/authenticators/ethSig.ts
@@ -1,0 +1,37 @@
+import * as utils from '../utils';
+import type { Call } from 'starknet';
+import type { Authenticator, Envelope, EthSigProposeMessage, EthSigVoteMessage } from '../types';
+
+const ethSigAuthenticator: Authenticator = {
+  type: 'ethSig',
+  createCall(
+    envelope: Envelope<EthSigProposeMessage | EthSigVoteMessage>,
+    selector: string,
+    calldata: string[]
+  ): Call {
+    const { sig, data } = envelope;
+    const { space, authenticator, salt } = data.message;
+    const { r, s, v } = utils.encoding.getRSVFromSig(sig);
+    const rawSalt = utils.splitUint256.SplitUint256.fromHex(`0x${salt.toString(16)}`);
+
+    return {
+      contractAddress: authenticator,
+      entrypoint: 'authenticate',
+      calldata: [
+        r.low,
+        r.high,
+        s.low,
+        s.high,
+        v,
+        rawSalt.low,
+        rawSalt.high,
+        space,
+        selector,
+        calldata.length,
+        ...calldata
+      ]
+    };
+  }
+};
+
+export default ethSigAuthenticator;

--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -1,0 +1,15 @@
+import vanillaAuthenticator from './vanilla';
+import ethSigAuthenticator from './ethSig';
+import type { Authenticator } from '../types';
+
+const authenticators = {
+  '0x6ad07205a4d725c5c2b10c4f5fbdfaaa351c742fce7a5a22b2b56fd8d5afd62': vanillaAuthenticator,
+  '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643': ethSigAuthenticator
+};
+
+export function getAuthenticator(address: string): Authenticator | null {
+  const authenticator = authenticators[address];
+  if (!authenticator) return null;
+
+  return authenticator;
+}

--- a/src/authenticators/vanilla.ts
+++ b/src/authenticators/vanilla.ts
@@ -1,0 +1,21 @@
+import type { Call } from 'starknet';
+import type { Authenticator, Envelope, VanillaProposeMessage, VanillaVoteMessage } from '../types';
+
+const vanillaAuthenticator: Authenticator = {
+  type: 'vanilla',
+  createCall(
+    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+    selector: string,
+    calldata: string[]
+  ): Call {
+    const { space, authenticator } = envelope.data.message;
+
+    return {
+      contractAddress: authenticator,
+      entrypoint: 'authenticate',
+      calldata: [space, selector, calldata.length, ...calldata]
+    };
+  }
+};
+
+export default vanillaAuthenticator;

--- a/src/clients/starknet-tx/constants.ts
+++ b/src/clients/starknet-tx/constants.ts
@@ -1,8 +1,4 @@
 export default {
-  authenticators: {
-    '0x6ad07205a4d725c5c2b10c4f5fbdfaaa351c742fce7a5a22b2b56fd8d5afd62': 'vanilla',
-    '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643': 'ethSig'
-  },
   strategies: {
     '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865': 'vanilla',
     '0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6': 'singleSlotProof'

--- a/src/clients/starknet-tx/contracts.ts
+++ b/src/clients/starknet-tx/contracts.ts
@@ -1,12 +1,5 @@
 import constants from './constants';
 
-export function getAuthenticatorType(address: string): 'vanilla' | 'ethSig' | null {
-  const type = constants.authenticators[address];
-
-  if (type !== 'vanilla' && type !== 'ethSig') return null;
-  return type;
-}
-
 export function getStrategyType(address: string): 'vanilla' | 'singleSlotProof' | null {
   const type = constants.strategies[address];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+import type { Call } from 'starknet';
+
+export interface Authenticator {
+  type: string;
+  createCall(envelope: Envelope<Message>, selector: string, calldata: string[]): Call;
+}
+
 export interface Propose {
   space: string;
   authenticator: string;

--- a/test/unit/authenticators/ethSig.test.ts
+++ b/test/unit/authenticators/ethSig.test.ts
@@ -1,0 +1,33 @@
+import { hash } from 'starknet';
+import ethSigAuthenticator from '../../../src/authenticators/ethSig';
+import { envelope } from './fixtures';
+
+describe('ethSigAuthenticator', () => {
+  it('should return type', () => {
+    expect(ethSigAuthenticator.type).toBe('ethSig');
+  });
+
+  it('should create call', () => {
+    const call = ethSigAuthenticator.createCall(envelope, hash.getSelectorFromName('propose'), [
+      '0x15'
+    ]);
+
+    expect(call).toEqual({
+      calldata: [
+        '0x74c87146c9ec0e37400019d3b5e73300',
+        '0x9477b6bae1534ea017fc44d8df019dcd',
+        '0x6a24d54eb1b496f88f04c467a9574f21',
+        '0x10f89f8c80474f42f7d9a125156e8dc2',
+        '0x1c',
+        '0xa7e8ddee',
+        '0x0',
+        '0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8',
+        '0x1bfd596ae442867ef71ca523061610682af8b00fc2738329422f4ad8d220b81',
+        1,
+        '0x15'
+      ],
+      contractAddress: '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643',
+      entrypoint: 'authenticate'
+    });
+  });
+});

--- a/test/unit/authenticators/fixtures.ts
+++ b/test/unit/authenticators/fixtures.ts
@@ -1,0 +1,24 @@
+export const envelope = {
+  address: '0x0BF8dE8Fc51002c9fE7cb29352dcaCb757d0364b',
+  sig: '0x9477b6bae1534ea017fc44d8df019dcd74c87146c9ec0e37400019d3b5e7330010f89f8c80474f42f7d9a125156e8dc26a24d54eb1b496f88f04c467a9574f211c',
+  data: {
+    domain: { name: 'snapshot-x', version: '1' },
+    types: {
+      Propose: [
+        { name: 'space', type: 'bytes32' },
+        { name: 'executionHash', type: 'bytes32' },
+        { name: 'metadataURI', type: 'string' },
+        { name: 'salt', type: 'uint256' }
+      ]
+    },
+    message: {
+      space: '0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8',
+      authenticator: '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643',
+      strategies: ['0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6'],
+      metadataURI: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca',
+      executionParams: [],
+      executionHash: '0x049ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804',
+      salt: 2817056238
+    }
+  }
+};

--- a/test/unit/authenticators/index.test.ts
+++ b/test/unit/authenticators/index.test.ts
@@ -1,0 +1,21 @@
+import { getAuthenticator } from '../../../src/authenticators';
+
+describe('authenticators', () => {
+  describe('getAuthenticator', () => {
+    it('should return correct authenticator with predefined addresses', () => {
+      expect(
+        getAuthenticator('0x6ad07205a4d725c5c2b10c4f5fbdfaaa351c742fce7a5a22b2b56fd8d5afd62')?.type
+      ).toBe('vanilla');
+
+      expect(
+        getAuthenticator('0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643')?.type
+      ).toBe('ethSig');
+    });
+
+    it('should return null for unknown authenticators', () => {
+      expect(
+        getAuthenticator('0x000000000000000000000000000000000000000000000000000000000000000')
+      ).toBe(null);
+    });
+  });
+});

--- a/test/unit/authenticators/vanilla.test.ts
+++ b/test/unit/authenticators/vanilla.test.ts
@@ -1,0 +1,26 @@
+import { hash } from 'starknet';
+import vanillaAuthenticator from '../../../src/authenticators/vanilla';
+import { envelope } from './fixtures';
+
+describe('vanillaAuthenticator', () => {
+  it('should return type', () => {
+    expect(vanillaAuthenticator.type).toBe('vanilla');
+  });
+
+  it('should create call', () => {
+    const call = vanillaAuthenticator.createCall(envelope, hash.getSelectorFromName('propose'), [
+      '0x15'
+    ]);
+
+    expect(call).toEqual({
+      calldata: [
+        '0x069555971fbf76b3d0471297818ed93986fdd7afe3816d53ea8d8e72034260d8',
+        '0x1bfd596ae442867ef71ca523061610682af8b00fc2738329422f4ad8d220b81',
+        1,
+        '0x15'
+      ],
+      contractAddress: '0x594a81b66c3aa2c64577916f727e1307b60c9d6afa80b6f5ca3e3049c40f643',
+      entrypoint: 'authenticate'
+    });
+  });
+});


### PR DESCRIPTION
Creates `Authenticator` interface that StarknetTx client uses to build call for propose/vote methods.

Right now authenticators are simple objects (instead of classes) as they shouldn't need internal state so this way it's cleaner, but we can see how it scales and change it if needed - as it's already an interface it won't be hard to migrate.

## Test plan
- Tests pass.
- Try creating proposal (or voting) with vanilla + ethSig authenticators (same as before, by using `.only` in test:integration).