### PR TITLE
Using short str arrays for metadata uri encoding

### DIFF
--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -97,7 +97,7 @@ export class StarkNetTx {
 
     return utils.encoding.getProposeCalldata(
       address,
-      utils.intsSequence.IntsSequence.LEFromString(metadataURI),
+      metadataURI,
       constants.executor,
       strategies,
       strategiesParams,

--- a/src/utils/encoding/calldata.ts
+++ b/src/utils/encoding/calldata.ts
@@ -1,5 +1,6 @@
 import { Choice } from '../choice';
 import { IntsSequence } from '../ints-sequence';
+import { strToShortStringArr } from '../strings';
 
 /**
  * Currently there is no way to pass struct types with pointers in calldata, so we must pass the 2d array as a flat array and then reconstruct the type.
@@ -37,18 +38,18 @@ export function flatten2DArray(array2D: string[][]): string[] {
  */
 export function getProposeCalldata(
   proposerAddress: string,
-  metadataUri: IntsSequence,
+  metadataUri: string,
   executorAddress: string,
   usedVotingStrategies: string[],
   usedVotingStrategyParams: string[][],
   executionParams: string[]
 ): string[] {
   const usedVotingStrategyParamsFlat = flatten2DArray(usedVotingStrategyParams);
+  const metadataUriShortStringArr = strToShortStringArr(metadataUri);
   return [
     proposerAddress,
-    `0x${metadataUri.bytesLength.toString(16)}`,
-    `0x${metadataUri.values.length.toString(16)}`,
-    ...metadataUri.values,
+    `0x${metadataUriShortStringArr.length.toString(16)}`,
+    ...metadataUriShortStringArr,
     executorAddress,
     `0x${usedVotingStrategies.length.toString(16)}`,
     ...usedVotingStrategies,

--- a/src/utils/ints-sequence.ts
+++ b/src/utils/ints-sequence.ts
@@ -27,13 +27,13 @@ export class IntsSequence {
   }
 
   asStrings(): string[] {
-    return this.values.map(s => {
+    return this.values.map((s) => {
       let str = '';
       for (let n = 2; n < s.length; n += 2) {
         str += String.fromCharCode(parseInt(s.substring(n, n + 2), 16));
       }
-      return str
-    })
+      return str;
+    });
   }
 
   static fromString(str: string): IntsSequence {
@@ -44,7 +44,6 @@ export class IntsSequence {
     }
     return new IntsSequence(intsArray, str.length);
   }
-
 
   static LEFromString(str: string): IntsSequence {
     const intsArray: string[] = [];

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,20 +1,19 @@
 const SHORT_STR_SIZE = 31;
 
-export function shortStrToFelt(str: string): bigint {
+export function shortStrToFelt(str: string): string {
   let res = '0x';
-  // String too big
-  if (str.length > SHORT_STR_SIZE) return BigInt(0);
+  if (str.length > SHORT_STR_SIZE) throw 'String too big';
   for (let i = 0; i < str.length; i++) {
     let toAdd = str.charCodeAt(i).toString(16);
     // If value is < 10, prefix with a 0
-    if (toAdd.length % 2 !== 0) toAdd = '0' + toAdd;
+    if (toAdd.length % 2 !== 0) toAdd = `0${toAdd}`;
     res += toAdd;
   }
-  return BigInt(res);
+  return res;
 }
 
-export function strToShortStringArr(str: string): Array<bigint> {
-  const res: Array<bigint> = [];
+export function strToShortStringArr(str: string): string[] {
+  const res: string[] = [];
   for (let i = 0; i < str.length; i += SHORT_STR_SIZE) {
     const temp = str.slice(i, i + SHORT_STR_SIZE);
     res.push(shortStrToFelt(temp));
@@ -22,11 +21,11 @@ export function strToShortStringArr(str: string): Array<bigint> {
   return res;
 }
 
-export function shortStringToStr(shortStringArr: bigint): string {
+export function shortStringToStr(shortStringArr: string): string {
   let res = '';
-  const hexForm = shortStringArr.toString(16);
+  const hexForm = shortStringArr.toString();
   const chunkSize = 2;
-  if (hexForm.length % chunkSize !== 0) throw 'ERROR IN PARSING';
+  if (hexForm.length % chunkSize !== 0) throw 'Error in Parsing';
   for (let i = 0; i < hexForm.length; i += chunkSize) {
     const s = parseInt(hexForm.slice(i, i + chunkSize), 16);
     res += String.fromCharCode(s);
@@ -34,7 +33,7 @@ export function shortStringToStr(shortStringArr: bigint): string {
   return res;
 }
 
-export function shortStringArrToStr(shortStringArr: Array<bigint>): string {
+export function shortStringArrToStr(shortStringArr: string[]): string {
   let res = '';
   for (const shortStr of shortStringArr) {
     res += shortStringToStr(shortStr);


### PR DESCRIPTION
Also migrate short string lib to using strings as the base type rather than bigints