### PR TITLE
feat: fetch strategy params from network

### DIFF
--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -17,7 +17,6 @@ import {
 const { getSelectorFromName } = hash;
 
 const TEMP_CONSTANTS = {
-  strategyParams: ['0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', '0x3'],
   block: 7541970
 };
 
@@ -38,7 +37,7 @@ export class StarkNetTx {
         const strategy = getStrategy(address);
         if (!strategy) throw new Error('Invalid strategy');
 
-        return strategy.getParams(envelope, metadata, this.config);
+        return strategy.getParams(address, envelope, metadata, this.config);
       })
     );
   }
@@ -51,7 +50,7 @@ export class StarkNetTx {
         const strategy = getStrategy(address);
         if (!strategy) throw new Error('Invalid strategy');
 
-        return strategy.getExtraProposeCalls(envelope, metadata, this.config);
+        return strategy.getExtraProposeCalls(address, envelope, metadata, this.config);
       })
     );
 

--- a/src/strategies/singleSlotProof.ts
+++ b/src/strategies/singleSlotProof.ts
@@ -1,3 +1,4 @@
+import { defaultProvider } from 'starknet';
 import { utils } from '..';
 import type { Call } from 'starknet';
 import type {
@@ -8,15 +9,46 @@ import type {
   VanillaProposeMessage,
   VanillaVoteMessage
 } from '../types';
+import { getStorageVarAddress } from '../utils/encoding';
 
+const strategyParamsStore = 'Voting_voting_strategy_params_store';
 const fossilFactRegistryAddress =
   '0x363108ac1521a47b4f7d82f8ba868199bc1535216bbedfc1b071ae93cc406fd';
 
+async function fetchStrategyParams(
+  address: string,
+  envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>
+): Promise<string[]> {
+  const lengthAddress = getStorageVarAddress(strategyParamsStore, address, '0x0');
+  const length = parseInt(
+    (await defaultProvider.getStorageAt(envelope.data.message.space, lengthAddress)) as string,
+    16
+  );
+
+  return Promise.all(
+    [...Array(length)].map(async (_, i) => {
+      const lengthAddress = getStorageVarAddress(
+        strategyParamsStore,
+        address,
+        (i + 1).toString(16)
+      );
+
+      return defaultProvider.getStorageAt(
+        envelope.data.message.space,
+        lengthAddress
+      ) as Promise<string>;
+    })
+  );
+}
+
 async function fetchProof(
+  address: string,
   envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
   metadata: Metadata,
   clientConfig: ClientConfig
 ) {
+  const strategyParams = await fetchStrategyParams(address, envelope);
+
   const response = await fetch(clientConfig.ethUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -25,8 +57,8 @@ async function fetchProof(
       id: 1,
       method: 'eth_getProof',
       params: [
-        metadata.strategyParams[0],
-        [utils.encoding.getSlotKey(envelope.address, metadata.strategyParams[1])],
+        strategyParams[0],
+        [utils.encoding.getSlotKey(envelope.address, strategyParams[1])],
         `0x${metadata.block.toString(16)}`
       ]
     })
@@ -41,21 +73,23 @@ async function fetchProof(
 const singleSlotProofStrategy: Strategy = {
   type: 'singleSlotProof',
   async getParams(
+    address: string,
     envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
     metadata: Metadata,
     clientConfig: ClientConfig
   ): Promise<string[]> {
-    const proof = await fetchProof(envelope, metadata, clientConfig);
+    const proof = await fetchProof(address, envelope, metadata, clientConfig);
     const proofInputs = utils.storageProofs.getProofInputs(metadata.block, proof);
 
     return proofInputs.storageProofs[0];
   },
   async getExtraProposeCalls(
+    address: string,
     envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
     metadata: Metadata,
     clientConfig: ClientConfig
   ): Promise<Call[]> {
-    const proof = await fetchProof(envelope, metadata, clientConfig);
+    const proof = await fetchProof(address, envelope, metadata, clientConfig);
     const proofInputs = utils.storageProofs.getProofInputs(metadata.block, proof);
 
     return [

--- a/src/strategies/vanilla.ts
+++ b/src/strategies/vanilla.ts
@@ -13,6 +13,7 @@ import type {
 const vanillaStrategy: Strategy = {
   type: 'vanilla',
   async getParams(
+    address: string,
     envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
     metadata: Metadata,
     clientConfig: ClientConfig
@@ -20,6 +21,7 @@ const vanillaStrategy: Strategy = {
     return [];
   },
   async getExtraProposeCalls(
+    address: string,
     envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
     metadata: Metadata,
     clientConfig: ClientConfig

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,13 @@ export interface Authenticator {
 export interface Strategy {
   type: string;
   getParams(
+    address: string,
     envelope: Envelope<Message>,
     metadata: Metadata,
     clientConfig: ClientConfig
   ): Promise<string[]>;
   getExtraProposeCalls(
+    address: string,
     envelope: Envelope<Message>,
     metadata: Metadata,
     clientConfig: ClientConfig
@@ -64,5 +66,4 @@ export type Envelope<T extends Message> = {
 
 export type Metadata = {
   block: number;
-  strategyParams: string[];
 };

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -4,3 +4,4 @@ export * from './calldata';
 export * from './starknet-commit';
 export * from './starknet-execution-params';
 export * from './eth-sig';
+export * from './storage-vars';

--- a/src/utils/encoding/storage-vars.ts
+++ b/src/utils/encoding/storage-vars.ts
@@ -1,0 +1,23 @@
+import { hash } from 'starknet';
+import BN from 'bn.js';
+
+const MAX_STORAGE_ITEM_SIZE = new BN(256);
+const ADDR_BOUND = new BN(2).pow(new BN(251)).sub(MAX_STORAGE_ITEM_SIZE);
+
+/**
+ * Returns the storage address of a StarkNet storage variable given its name and arguments.
+ * https://github.com/starkware-libs/cairo-lang/blob/d61255f32a7011e9014e1204471103c719cfd5cb/src/starkware/starknet/public/abi.py#L60-L70
+ * @param varName storage_var name
+ * @param args additional arguments
+ */
+export function getStorageVarAddress(varName: string, ...args: string[]) {
+  let res = hash.starknetKeccak(varName);
+
+  for (const arg of args) {
+    const computedHash = hash.pedersen([res, new BN(arg.replace('0x', ''), 'hex')]);
+
+    res = new BN(computedHash.replace('0x', ''), 'hex');
+  }
+
+  return res.mod(ADDR_BOUND).toString();
+}

--- a/test/unit/strategies/singleSlotProof.test.ts
+++ b/test/unit/strategies/singleSlotProof.test.ts
@@ -9,15 +9,25 @@ describe('singleSlotProofStrategy', () => {
   });
 
   it('should return params', async () => {
-    const params = await singleSlotProofStrategy.getParams(envelope, metadata, { ethUrl });
+    const params = await singleSlotProofStrategy.getParams(
+      '0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6',
+      envelope,
+      metadata,
+      { ethUrl }
+    );
 
     expect(params).toMatchSnapshot();
   });
 
   it('should return extra propose calls', async () => {
-    const params = await singleSlotProofStrategy.getExtraProposeCalls(envelope, metadata, {
-      ethUrl
-    });
+    const params = await singleSlotProofStrategy.getExtraProposeCalls(
+      '0x4bbd8081b1e9ef84ee2a767ef2cdcdea0dd8298b8e2858afa06bed1898533e6',
+      envelope,
+      metadata,
+      {
+        ethUrl
+      }
+    );
 
     expect(params).toMatchSnapshot();
   });

--- a/test/unit/strategies/vanilla.test.ts
+++ b/test/unit/strategies/vanilla.test.ts
@@ -9,13 +9,23 @@ describe('vanillaStrategy', () => {
   });
 
   it('should return params', async () => {
-    const params = await vanillaStrategy.getParams(envelope, metadata, { ethUrl });
+    const params = await vanillaStrategy.getParams(
+      '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
+      envelope,
+      metadata,
+      { ethUrl }
+    );
 
     expect(params).toEqual([]);
   });
 
   it('should return extra propose calls', async () => {
-    const params = await vanillaStrategy.getExtraProposeCalls(envelope, metadata, { ethUrl });
+    const params = await vanillaStrategy.getExtraProposeCalls(
+      '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
+      envelope,
+      metadata,
+      { ethUrl }
+    );
 
     expect(params).toEqual([]);
   });

--- a/test/unit/utils/encoding/storage-vars.test.ts
+++ b/test/unit/utils/encoding/storage-vars.test.ts
@@ -1,0 +1,25 @@
+import { getStorageVarAddress } from '../../../../src/utils/encoding';
+
+describe('storageVars', () => {
+  describe('getStorageVarAddress', () => {
+    it('should calculate address for strage var with no arguments', () => {
+      const address = getStorageVarAddress('Voting_num_voting_strategies_store');
+
+      expect(address).toBe(
+        '1132603603708845750901293048689264183551203819688552254429518139992977083884'
+      );
+    });
+
+    it('should calculate address with arguments', () => {
+      const address = getStorageVarAddress(
+        'Voting_voting_strategy_params_store',
+        '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
+        '0x0'
+      );
+
+      expect(address).toBe(
+        '3489048192089559476903748062948486950202000883027513154877959712418600200866'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Instead of using hardcoded strategy params (that we use to fetch correct proofs) they are now fetched from the network.
Block is hardcoded still, as in current state we 

## Test plan
- Create proposal with SSP.