### PR TITLE
fix: encode proposalID with 0x prefix

### DIFF
--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -85,13 +85,7 @@ export class StarkNetTx {
 
     const strategiesParams = await this.getStrategiesParams(envelope, metadata);
 
-    return utils.encoding.getVoteCalldata(
-      address,
-      proposal.toString(16),
-      Number(choice),
-      strategies,
-      strategiesParams
-    );
+    return utils.encoding.getVoteCalldata(address, proposal, choice, strategies, strategiesParams);
   }
 
   async propose(

--- a/src/utils/encoding/calldata.ts
+++ b/src/utils/encoding/calldata.ts
@@ -70,7 +70,7 @@ export function getProposeCalldata(
  */
 export function getVoteCalldata(
   voterAddress: string,
-  proposalID: string,
+  proposalID: number,
   choice: Choice,
   usedVotingStrategies: string[],
   usedVotingStrategyParams: string[][]
@@ -78,7 +78,7 @@ export function getVoteCalldata(
   const usedVotingStrategyParamsFlat = flatten2DArray(usedVotingStrategyParams);
   return [
     voterAddress,
-    proposalID,
+    `0x${proposalID.toString(16)}`,
     `0x${choice.toString(16)}`,
     `0x${usedVotingStrategies.length.toString(16)}`,
     ...usedVotingStrategies,


### PR DESCRIPTION
`.toString(16)` return value was missing `0x` prefix and it was failing when going to 10 and above.

Made `getVoteCalldata` accept number, similar to choice and make it encode it internally.