### PR TITLE
test: make unit tests deterministic

### DIFF
--- a/test/unit/strategies/singleSlotProof.test.ts
+++ b/test/unit/strategies/singleSlotProof.test.ts
@@ -1,9 +1,35 @@
+import { defaultProvider } from 'starknet';
 import singleSlotProofStrategy from '../../../src/strategies/singleSlotProof';
+import { getStorageVarAddress } from '../../../src/utils/encoding';
 import { proposeEnvelope, voteEnvelope } from '../fixtures';
 
 const ethUrl = process.env.GOERLI_NODE_URL as string;
 
+const latestL1Block = 7541971;
+
 describe('singleSlotProofStrategy', () => {
+  let getStorageAtSpy;
+  beforeAll(() => {
+    const getStorageAt = defaultProvider.getStorageAt;
+
+    getStorageAtSpy = jest
+      .spyOn(defaultProvider, 'getStorageAt')
+      .mockImplementation((contractAddress, key) => {
+        if (
+          contractAddress === '0x6ca3d25e901ce1fff2a7dd4079a24ff63ca6bbf8ba956efc71c1467975ab78f' &&
+          key === getStorageVarAddress('_latest_l1_block')
+        ) {
+          return Promise.resolve(latestL1Block.toString(16));
+        }
+
+        return getStorageAt.call(defaultProvider, contractAddress, key);
+      });
+  });
+
+  afterAll(() => {
+    getStorageAtSpy.mockRestore();
+  });
+
   it('should return type', () => {
     expect(singleSlotProofStrategy.type).toBe('singleSlotProof');
   });


### PR DESCRIPTION
Makes tests deterministic by mocking latestL1Block so it always gets the same results no matter the network state.

## Test plan
- Tests should pass.