### PR TITLE
chore: bump version to 0.1.0-beta.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/sx",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumping version so we can release it and use it in mana/sx-ui.