### PR TITLE
Decoding function for packed felts

### DIFF
--- a/src/utils/encoding/felt-packing.ts
+++ b/src/utils/encoding/felt-packing.ts
@@ -1,0 +1,15 @@
+/**
+ * Unpacks 4 32 bit numbers from a hex string
+ * @param packed The hex string that contains the packed values
+ * @returns Array of 4 32 bit hex strings
+ */
+export function unpack4x32Bit(packed: string): string[] {
+  if (packed.slice(0, 2) == '0x') {
+    packed = packed.slice(2);
+  }
+  const num4 = `0x${packed.slice(-8)}`;
+  const num3 = `0x${packed.slice(-16, -8)}`;
+  const num2 = `0x${packed.slice(-24, -16)}`;
+  const num1 = `0x${packed.slice(-32, -24)}`;
+  return [num1, num2, num3, num4];
+}

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -5,3 +5,4 @@ export * from './starknet-commit';
 export * from './starknet-execution-params';
 export * from './eth-sig';
 export * from './storage-vars';
+export * from './felt-packing';


### PR DESCRIPTION
We now pack the timestamps in the proposal struct in the space contract to save gas. 
https://github.com/snapshot-labs/sx-core/blob/pack_proposal_struct/contracts/starknet/lib/proposal.cairo
Use this function to decode the packed value into the 4 timestamps