### PR TITLE
added default strategies and authenticators

### DIFF
--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -3,12 +3,14 @@ import ethSigAuthenticator from './ethSig';
 import * as utils from '../utils';
 import type { Authenticator } from '../types';
 
+const defaultAuthenticators = {
+  '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e83500': vanillaAuthenticator,
+  '0x06aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': ethSigAuthenticator
+}
+
 export function getAuthenticator(
   address: string,
-  authenticators: any = {
-    '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e83500': vanillaAuthenticator,
-    '0x06aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': ethSigAuthenticator
-  }
+  authenticators: any = defaultAuthenticators
 ): Authenticator | null {
   const authenticator = authenticators[utils.encoding.hexPadRight(address)];
   if (!authenticator) return null;

--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -3,12 +3,13 @@ import ethSigAuthenticator from './ethSig';
 import * as utils from '../utils';
 import type { Authenticator } from '../types';
 
-const authenticators = {
-  '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e83500': vanillaAuthenticator,
-  '0x06aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': ethSigAuthenticator
-};
-
-export function getAuthenticator(address: string): Authenticator | null {
+export function getAuthenticator(
+  address: string,
+  authenticators: any = {
+    '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e83500': vanillaAuthenticator,
+    '0x06aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': ethSigAuthenticator
+  }
+): Authenticator | null {
   const authenticator = authenticators[utils.encoding.hexPadRight(address)];
   if (!authenticator) return null;
 

--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -6,7 +6,7 @@ import type { Authenticator } from '../types';
 const defaultAuthenticators = {
   '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e83500': vanillaAuthenticator,
   '0x06aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': ethSigAuthenticator
-}
+};
 
 export function getAuthenticator(
   address: string,

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -3,12 +3,13 @@ import singleSlotProofStrategy from './singleSlotProof';
 import * as utils from '../utils';
 import type { Strategy } from '../types';
 
-const strategies = {
-  '0x0515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': vanillaStrategy,
-  '0x068da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': singleSlotProofStrategy
-};
-
-export function getStrategy(address: string): Strategy | null {
+export function getStrategy(
+  address: string,
+  strategies: any = {
+    '0x0515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': vanillaStrategy,
+    '0x068da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': singleSlotProofStrategy
+  }
+): Strategy | null {
   const strategy = strategies[utils.encoding.hexPadRight(address)];
   if (!strategy) return null;
 

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -3,12 +3,14 @@ import singleSlotProofStrategy from './singleSlotProof';
 import * as utils from '../utils';
 import type { Strategy } from '../types';
 
+const defaultStrategies = {
+  '0x0515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': vanillaStrategy,
+  '0x068da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': singleSlotProofStrategy
+}
+
 export function getStrategy(
   address: string,
-  strategies: any = {
-    '0x0515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': vanillaStrategy,
-    '0x068da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': singleSlotProofStrategy
-  }
+  strategies: any = defaultStrategies
 ): Strategy | null {
   const strategy = strategies[utils.encoding.hexPadRight(address)];
   if (!strategy) return null;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -6,12 +6,9 @@ import type { Strategy } from '../types';
 const defaultStrategies = {
   '0x0515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': vanillaStrategy,
   '0x068da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': singleSlotProofStrategy
-}
+};
 
-export function getStrategy(
-  address: string,
-  strategies: any = defaultStrategies
-): Strategy | null {
+export function getStrategy(address: string, strategies: any = defaultStrategies): Strategy | null {
   const strategy = strategies[utils.encoding.hexPadRight(address)];
   if (!strategy) return null;
 

--- a/test/unit/authenticators/index.test.ts
+++ b/test/unit/authenticators/index.test.ts
@@ -1,14 +1,36 @@
 import { getAuthenticator } from '../../../src/authenticators';
+import vanillaAuthenticator from '../../../src/authenticators/vanilla';
+import ethSigAuthenticator from '../../../src/authenticators/ethSig';
 
 describe('authenticators', () => {
   describe('getAuthenticator', () => {
-    it('should return correct authenticator with predefined addresses', () => {
+    it('should return correct authenticator from predefined default addresses', () => {
       expect(
         getAuthenticator('0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e835')?.type
       ).toBe('vanilla');
 
       expect(
         getAuthenticator('0x6aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369')?.type
+      ).toBe('ethSig');
+    });
+
+    it('should return correct authenticator from supplied addresses', () => {
+      const authenticators = {
+        '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922': vanillaAuthenticator,
+        '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9': ethSigAuthenticator
+      };
+      expect(
+        getAuthenticator(
+          '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922',
+          authenticators
+        )?.type
+      ).toBe('vanilla');
+
+      expect(
+        getAuthenticator(
+          '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9',
+          authenticators
+        )?.type
       ).toBe('ethSig');
     });
 

--- a/test/unit/strategies/index.test.ts
+++ b/test/unit/strategies/index.test.ts
@@ -15,7 +15,7 @@ describe('voting strategies', () => {
     });
 
     it('should return correct strategy from supplied addresses', () => {
-      const Strategies = {
+      const strategies = {
         '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922': vanillaStrategy,
         '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9':
           singleSlotProofStrategy
@@ -23,14 +23,14 @@ describe('voting strategies', () => {
       expect(
         getStrategy(
           '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922',
-          Strategies
+          strategies
         )?.type
       ).toBe('vanilla');
 
       expect(
         getStrategy(
           '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9',
-          Strategies
+          strategies
         )?.type
       ).toBe('singleSlotProof');
     });

--- a/test/unit/strategies/index.test.ts
+++ b/test/unit/strategies/index.test.ts
@@ -1,8 +1,10 @@
 import { getStrategy } from '../../../src/strategies';
+import vanillaStrategy from '../../../src/strategies/vanilla';
+import singleSlotProofStrategy from '../../../src/strategies/singleSlotProof';
 
-describe('strategies', () => {
-  describe('getAuthenticator', () => {
-    it('should return correct authenticator with predefined addresses', () => {
+describe('voting strategies', () => {
+  describe('getStrategy', () => {
+    it('should return correct strategy from predefined default addresses', () => {
       expect(
         getStrategy('0x515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71')?.type
       ).toBe('vanilla');
@@ -12,7 +14,28 @@ describe('strategies', () => {
       ).toBe('singleSlotProof');
     });
 
-    it('should return null for unknown authenticators', () => {
+    it('should return correct strategy from supplied addresses', () => {
+      const Strategies = {
+        '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922': vanillaStrategy,
+        '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9':
+          singleSlotProofStrategy
+      };
+      expect(
+        getStrategy(
+          '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922',
+          Strategies
+        )?.type
+      ).toBe('vanilla');
+
+      expect(
+        getStrategy(
+          '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9',
+          Strategies
+        )?.type
+      ).toBe('singleSlotProof');
+    });
+
+    it('should return null for unknown strategies', () => {
       expect(getStrategy('0x000000000000000000000000000000000000000000000000000000000000000')).toBe(
         null
       );


### PR DESCRIPTION
we add a default to the `getStrategy` and `getAuthenticator` functions, but users are able to specify an alternative object. No breaking change

closes https://github.com/snapshot-labs/sx.js/issues/98