### PR TITLE
feat: add executors

### DIFF
--- a/src/executors/ethRelayer.ts
+++ b/src/executors/ethRelayer.ts
@@ -1,0 +1,20 @@
+import { createExecutionHash, MetaTransaction } from '../utils/encoding/execution-hash';
+import { SplitUint256 } from '../utils/split-uint256';
+
+export class EthRelayerExecutor {
+  executor: string;
+
+  constructor(executor: string) {
+    this.executor = executor;
+  }
+
+  getExecutionData(destination: string, transactions: MetaTransaction[], chainId: number) {
+    const { executionHash } = createExecutionHash(transactions, destination, chainId);
+    const executionHashSplit = SplitUint256.fromHex(executionHash);
+
+    return {
+      executor: this.executor,
+      executionParams: [destination, executionHashSplit.low, executionHashSplit.high]
+    };
+  }
+}

--- a/src/executors/ethRelayer.ts
+++ b/src/executors/ethRelayer.ts
@@ -1,20 +1,24 @@
 import { createExecutionHash, MetaTransaction } from '../utils/encoding/execution-hash';
 import { SplitUint256 } from '../utils/split-uint256';
 
-export class EthRelayerExecutor {
-  executor: string;
-
-  constructor(executor: string) {
-    this.executor = executor;
+const CONSTANTS = {
+  '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b': {
+    destination: '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
+    chainId: 5
   }
+};
 
-  getExecutionData(destination: string, transactions: MetaTransaction[], chainId: number) {
+export const ethRelayerExecutor = {
+  type: 'ethRelayer',
+  getExecutionData(executorAddress: keyof typeof CONSTANTS, transactions: MetaTransaction[]) {
+    const { destination, chainId } = CONSTANTS[executorAddress];
+
     const { executionHash } = createExecutionHash(transactions, destination, chainId);
     const executionHashSplit = SplitUint256.fromHex(executionHash);
 
     return {
-      executor: this.executor,
+      executor: executorAddress,
       executionParams: [destination, executionHashSplit.low, executionHashSplit.high]
     };
   }
-}
+};

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -1,3 +1,38 @@
-export * from './ethRelayer';
-export * from './starknet';
-export * from './vanilla';
+import type { ExecutionInput } from '../types';
+import { ethRelayerExecutor } from './ethRelayer';
+import { starknetExecutor } from './starknet';
+import { vanillaExecutor } from './vanilla';
+
+type Executor = {
+  type: string;
+  getExecutionData(
+    executorAddress: string,
+    data?: any
+  ): {
+    executor: string;
+    executionParams: string[];
+  };
+};
+
+const executors: { [key: string]: Executor } = {
+  '1': starknetExecutor,
+  '0x70d94f64cfab000f8e26318f4413dfdaa1f19a3695e3222297edc62bbc936c7': vanillaExecutor,
+  '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b': ethRelayerExecutor
+};
+
+export function getExecutionData(executorAddress: string, input?: ExecutionInput) {
+  const executor = executors[executorAddress];
+  if (!executor) throw new Error(`Unknown executor ${executorAddress}`);
+
+  if (executor === starknetExecutor && input?.calls) {
+    return executor.getExecutionData(executorAddress, input.calls);
+  } else if (executor === ethRelayerExecutor && input?.transactions) {
+    return executor.getExecutionData(executorAddress, input.transactions);
+  } else if (executor === vanillaExecutor) {
+    return executor.getExecutionData(executorAddress);
+  }
+
+  throw new Error(`Not enough data to create execution for executor ${executorAddress}`);
+}
+
+export { ethRelayerExecutor, starknetExecutor, vanillaExecutor };

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -1,0 +1,3 @@
+export * from './ethRelayer';
+export * from './starknet';
+export * from './vanilla';

--- a/src/executors/starknet.ts
+++ b/src/executors/starknet.ts
@@ -1,10 +1,12 @@
-import { createStarknetExecutionParams, Call } from '../utils/encoding/starknet-execution-params';
+import { createStarknetExecutionParams } from '../utils/encoding/starknet-execution-params';
+import type { Call } from 'starknet';
 
-export class StarknetExecutor {
-  getExecutionData(calls: Call[]) {
+export const starknetExecutor = {
+  type: 'starknet',
+  getExecutionData(executorAddress: string, calls: Call[]) {
     return {
-      executor: '1',
+      executor: executorAddress,
       executionParams: createStarknetExecutionParams(calls)
     };
   }
-}
+};

--- a/src/executors/starknet.ts
+++ b/src/executors/starknet.ts
@@ -1,0 +1,10 @@
+import { createStarknetExecutionParams, Call } from '../utils/encoding/starknet-execution-params';
+
+export class StarknetExecutor {
+  getExecutionData(calls: Call[]) {
+    return {
+      executor: '1',
+      executionParams: createStarknetExecutionParams(calls)
+    };
+  }
+}

--- a/src/executors/vanilla.ts
+++ b/src/executors/vanilla.ts
@@ -1,0 +1,14 @@
+export class VanillaExecutor {
+  executor: string;
+
+  constructor(executor: string) {
+    this.executor = executor;
+  }
+
+  getExecutionData() {
+    return {
+      executor: this.executor,
+      executionParams: []
+    };
+  }
+}

--- a/src/executors/vanilla.ts
+++ b/src/executors/vanilla.ts
@@ -1,14 +1,9 @@
-export class VanillaExecutor {
-  executor: string;
-
-  constructor(executor: string) {
-    this.executor = executor;
-  }
-
-  getExecutionData() {
+export const vanillaExecutor = {
+  type: 'vanilla',
+  getExecutionData(executorAddress: string) {
     return {
-      executor: this.executor,
+      executor: executorAddress,
       executionParams: []
     };
   }
-}
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Provider } from 'starknet';
 import type { Call } from 'starknet';
 import type { Choice } from './utils/choice';
+import type { MetaTransaction } from './utils/encoding/execution-hash';
 
 export interface Authenticator {
   type: string;
@@ -78,4 +79,9 @@ export type Envelope<T extends Message> = {
   data: {
     message: T;
   };
+};
+
+export type ExecutionInput = {
+  calls?: Call[];
+  transactions?: MetaTransaction[];
 };

--- a/src/utils/encoding/starknet-execution-params.ts
+++ b/src/utils/encoding/starknet-execution-params.ts
@@ -1,8 +1,4 @@
-export interface Call {
-  to: string;
-  functionSelector: string;
-  calldata: string[];
-}
+import { hash, Call } from 'starknet';
 
 export function createStarknetExecutionParams(callArray: Call[]): string[] {
   if (!callArray || callArray.length == 0) {
@@ -14,18 +10,29 @@ export function createStarknetExecutionParams(callArray: Call[]): string[] {
   let calldataIndex = 0;
 
   callArray.forEach(tx => {
+    const calldata = tx.calldata || [];
+
     const subArr: string[] = [
-      tx.to,
-      tx.functionSelector,
+      tx.contractAddress,
+      hash.getSelectorFromName(tx.entrypoint),
       `0x${calldataIndex.toString(16)}`,
-      `0x${tx.calldata.length.toString(16)}`
+      `0x${calldata.length.toString(16)}`
     ];
-    calldataIndex += tx.calldata.length;
+    calldataIndex += calldata.length;
     executionParams.push(...subArr);
   });
 
   callArray.forEach(tx => {
-    executionParams.push(...tx.calldata);
+    if (!tx.calldata) return;
+
+    executionParams.push(
+      ...tx.calldata.map(value => {
+        if (typeof value === 'string') return value;
+
+        return `0x${value.toString(16)}`;
+      })
+    );
   });
+
   return executionParams;
 }

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -1,5 +1,5 @@
 import { StarkNetTx, EthereumSig } from '../../src/clients';
-import { EthRelayerExecutor } from '../../src/executors';
+import { getExecutionData } from '../../src/executors';
 import { Account, defaultProvider, ec } from 'starknet';
 import { Wallet } from '@ethersproject/wallet';
 import { Choice } from '../../src/utils/choice';
@@ -171,8 +171,7 @@ describe('StarkNetTx', () => {
     const strategy = 0;
 
     const executorAddress = '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b';
-    const executorDestination = '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca';
-    const executionTxs = [
+    const transactions = [
       {
         to: '0x2842c82E20ab600F443646e1BC8550B44a513D82',
         value: '0x0',
@@ -181,11 +180,9 @@ describe('StarkNetTx', () => {
         nonce: 0
       }
     ];
-    const chainId = 5;
 
     it('StarkNetTx.propose()', async () => {
-      const executor = new EthRelayerExecutor(executorAddress);
-      const executionData = executor.getExecutionData(executorDestination, executionTxs, chainId);
+      const executionData = getExecutionData(executorAddress, { transactions });
 
       const envelope = {
         address: walletAddress,

--- a/test/unit/executors/ethRelayer.test.ts
+++ b/test/unit/executors/ethRelayer.test.ts
@@ -1,0 +1,30 @@
+import { EthRelayerExecutor } from '../../../src/executors';
+
+describe('EthRelayerExecutor', () => {
+  const address = '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b';
+  const destination = '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca';
+  const txs = [
+    {
+      to: '0x2842c82E20ab600F443646e1BC8550B44a513D82',
+      value: '0x0',
+      data: '0x',
+      operation: 0,
+      nonce: 0
+    }
+  ];
+  const chainId = 5;
+
+  it('should create execution data', () => {
+    const executor = new EthRelayerExecutor(address);
+    const data = executor.getExecutionData(destination, txs, chainId);
+
+    expect(data).toEqual({
+      executor: address,
+      executionParams: [
+        '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
+        '0xa54ae382d03ab474d9d2ddd47d3fac68',
+        '0xb21b273bd32558c5eba5bb6576ac8592'
+      ]
+    });
+  });
+});

--- a/test/unit/executors/ethRelayer.test.ts
+++ b/test/unit/executors/ethRelayer.test.ts
@@ -1,8 +1,7 @@
-import { EthRelayerExecutor } from '../../../src/executors';
+import { ethRelayerExecutor } from '../../../src/executors';
 
-describe('EthRelayerExecutor', () => {
+describe('ethRelayerExecutor', () => {
   const address = '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b';
-  const destination = '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca';
   const txs = [
     {
       to: '0x2842c82E20ab600F443646e1BC8550B44a513D82',
@@ -12,11 +11,9 @@ describe('EthRelayerExecutor', () => {
       nonce: 0
     }
   ];
-  const chainId = 5;
 
   it('should create execution data', () => {
-    const executor = new EthRelayerExecutor(address);
-    const data = executor.getExecutionData(destination, txs, chainId);
+    const data = ethRelayerExecutor.getExecutionData(address, txs);
 
     expect(data).toEqual({
       executor: address,

--- a/test/unit/executors/index.test.ts
+++ b/test/unit/executors/index.test.ts
@@ -1,0 +1,78 @@
+import { getExecutionData } from '../../../src/executors';
+
+describe('getExecutionData', () => {
+  it('should create vanilla execution data', () => {
+    const address = '0x70d94f64cfab000f8e26318f4413dfdaa1f19a3695e3222297edc62bbc936c7';
+
+    const data = getExecutionData(address);
+
+    expect(data).toEqual({
+      executor: address,
+      executionParams: []
+    });
+  });
+
+  it('should create starknet execution data', () => {
+    const calls = [
+      {
+        contractAddress: '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
+        entrypoint: 'transfer',
+        calldata: ['0x01']
+      }
+    ];
+
+    const data = getExecutionData('1', { calls });
+
+    expect(data).toEqual({
+      executor: '1',
+      executionParams: [
+        '0x5',
+        '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
+        '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e',
+        '0x0',
+        '0x1',
+        '0x01'
+      ]
+    });
+  });
+
+  it('should create ethRelayer execution data', () => {
+    const address = '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b';
+    const transactions = [
+      {
+        to: '0x2842c82E20ab600F443646e1BC8550B44a513D82',
+        value: '0x0',
+        data: '0x',
+        operation: 0,
+        nonce: 0
+      }
+    ];
+
+    const data = getExecutionData(address, { transactions });
+
+    expect(data).toEqual({
+      executor: address,
+      executionParams: [
+        '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
+        '0xa54ae382d03ab474d9d2ddd47d3fac68',
+        '0xb21b273bd32558c5eba5bb6576ac8592'
+      ]
+    });
+  });
+
+  it('should throw if contract is unknown', () => {
+    const address = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+    expect(() => getExecutionData(address)).toThrowError(
+      'Unknown executor 0x0000000000000000000000000000000000000000000000000000000000000000'
+    );
+  });
+
+  it('should throw if inputs are missing', () => {
+    const address = '0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b';
+
+    expect(() => getExecutionData(address)).toThrowError(
+      'Not enough data to create execution for executor 0x790a2f60ac5a1743ebfad2a00b06d1c40866dc92eead76a7ede6c805bc29a4b'
+    );
+  });
+});

--- a/test/unit/executors/starknet.test.ts
+++ b/test/unit/executors/starknet.test.ts
@@ -1,0 +1,29 @@
+import { hash } from 'starknet';
+import { StarknetExecutor } from '../../../src/executors';
+
+describe('StarknetExecutor', () => {
+  const calls = [
+    {
+      to: '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
+      functionSelector: hash.getSelectorFromName('transfer'),
+      calldata: ['0x01']
+    }
+  ];
+
+  it('should create execution data', () => {
+    const executor = new StarknetExecutor();
+    const data = executor.getExecutionData(calls);
+
+    expect(data).toEqual({
+      executor: '1',
+      executionParams: [
+        '0x5',
+        '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
+        '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e',
+        '0x0',
+        '0x1',
+        '0x01'
+      ]
+    });
+  });
+});

--- a/test/unit/executors/starknet.test.ts
+++ b/test/unit/executors/starknet.test.ts
@@ -1,18 +1,16 @@
-import { hash } from 'starknet';
-import { StarknetExecutor } from '../../../src/executors';
+import { starknetExecutor } from '../../../src/executors';
 
-describe('StarknetExecutor', () => {
+describe('starknetExecutor', () => {
   const calls = [
     {
-      to: '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
-      functionSelector: hash.getSelectorFromName('transfer'),
+      contractAddress: '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',
+      entrypoint: 'transfer',
       calldata: ['0x01']
     }
   ];
 
   it('should create execution data', () => {
-    const executor = new StarknetExecutor();
-    const data = executor.getExecutionData(calls);
+    const data = starknetExecutor.getExecutionData('1', calls);
 
     expect(data).toEqual({
       executor: '1',

--- a/test/unit/executors/vanilla.test.ts
+++ b/test/unit/executors/vanilla.test.ts
@@ -1,11 +1,10 @@
-import { VanillaExecutor } from '../../../src/executors';
+import { vanillaExecutor } from '../../../src/executors';
 
-describe('VanillaExecutor', () => {
+describe('vanillaExecutor', () => {
   const address = '0x70d94f64cfab000f8e26318f4413dfdaa1f19a3695e3222297edc62bbc936c7';
 
   it('should create execution data', () => {
-    const executor = new VanillaExecutor(address);
-    const data = executor.getExecutionData();
+    const data = vanillaExecutor.getExecutionData(address);
 
     expect(data).toEqual({
       executor: address,

--- a/test/unit/executors/vanilla.test.ts
+++ b/test/unit/executors/vanilla.test.ts
@@ -1,0 +1,15 @@
+import { VanillaExecutor } from '../../../src/executors';
+
+describe('VanillaExecutor', () => {
+  const address = '0x70d94f64cfab000f8e26318f4413dfdaa1f19a3695e3222297edc62bbc936c7';
+
+  it('should create execution data', () => {
+    const executor = new VanillaExecutor(address);
+    const data = executor.getExecutionData();
+
+    expect(data).toEqual({
+      executor: address,
+      executionParams: []
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx.js/issues/95
Closes: https://github.com/snapshot-labs/sx.js/issues/96 (probably, because Starknet execution doesn't use execution hash)

This PR adds Executor classes that can be used to generate execution data for different types of executors (EthRelayer, Vanilla, Starknet).

- `Vanilla` - empty params
- `EthRelayer` - hash of transactions and L1 destination
- `Starknet` - encoded calls

`Starknet` executor doesn't use executionHash (it encodes whole calls), so it's impossible to abstract all of them to use single executionHash. What those executors accept as params are also different (for example EthRelayer takes txs, L1 destination and chainId while Starknet takes just calls) so it's hard to make it hands-off experience for the user, but it's now possible to use `getExecutionData` helper that will pick executor based on address (this will require client knowing what the argument need to be for it though).