### PR TITLE
fix: set chainId on starkProvider

### DIFF
--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -1,6 +1,6 @@
 import { StarkNetTx, EthereumSig } from '../../src/clients';
 import { getExecutionData } from '../../src/executors';
-import { Account, Provider, ec } from 'starknet';
+import { Account, Provider, ec, constants } from 'starknet';
 import { Wallet } from '@ethersproject/wallet';
 import { Choice } from '../../src/utils/choice';
 
@@ -13,7 +13,12 @@ describe('StarkNetTx', () => {
   const privKey = process.env.STARKNET_PK as string;
   const manaUrl = '';
 
-  const starkProvider = new Provider({ sequencer: { network: 'goerli-alpha-2' } });
+  const starkProvider = new Provider({
+    sequencer: {
+      baseUrl: 'https://alpha4-2.starknet.io',
+      chainId: constants.StarknetChainId.TESTNET2
+    }
+  });
 
   const wallet = Wallet.createRandom();
   const walletAddress = wallet.address;


### PR DESCRIPTION
Previous goerli2 testnet was deployed with bug that made it use goerli1 chainId, but it was changed today to use its own chainId.
`starknet` doesn't derive it properly from network so it needs to be set explicitly along the URL.