### PR TITLE
refactor: allow configuring network config at runtime

### DIFF
--- a/src/authenticators/ethSig.ts
+++ b/src/authenticators/ethSig.ts
@@ -2,36 +2,36 @@ import * as utils from '../utils';
 import type { Call } from 'starknet';
 import type { Authenticator, Envelope, EthSigProposeMessage, EthSigVoteMessage } from '../types';
 
-const ethSigAuthenticator: Authenticator = {
-  type: 'ethSig',
-  createCall(
-    envelope: Envelope<EthSigProposeMessage | EthSigVoteMessage>,
-    selector: string,
-    calldata: string[]
-  ): Call {
-    const { sig, data } = envelope;
-    const { space, authenticator, salt } = data.message;
-    const { r, s, v } = utils.encoding.getRSVFromSig(sig);
-    const rawSalt = utils.splitUint256.SplitUint256.fromHex(`0x${salt.toString(16)}`);
+export default function createEthSigAuthenticator(): Authenticator {
+  return {
+    type: 'ethSig',
+    createCall(
+      envelope: Envelope<EthSigProposeMessage | EthSigVoteMessage>,
+      selector: string,
+      calldata: string[]
+    ): Call {
+      const { sig, data } = envelope;
+      const { space, authenticator, salt } = data.message;
+      const { r, s, v } = utils.encoding.getRSVFromSig(sig);
+      const rawSalt = utils.splitUint256.SplitUint256.fromHex(`0x${salt.toString(16)}`);
 
-    return {
-      contractAddress: authenticator,
-      entrypoint: 'authenticate',
-      calldata: [
-        r.low,
-        r.high,
-        s.low,
-        s.high,
-        v,
-        rawSalt.low,
-        rawSalt.high,
-        space,
-        selector,
-        calldata.length,
-        ...calldata
-      ]
-    };
-  }
-};
-
-export default ethSigAuthenticator;
+      return {
+        contractAddress: authenticator,
+        entrypoint: 'authenticate',
+        calldata: [
+          r.low,
+          r.high,
+          s.low,
+          s.high,
+          v,
+          rawSalt.low,
+          rawSalt.high,
+          space,
+          selector,
+          calldata.length,
+          ...calldata
+        ]
+      };
+    }
+  };
+}

--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -1,19 +1,22 @@
-import vanillaAuthenticator from './vanilla';
-import ethSigAuthenticator from './ethSig';
+import createVanillaAuthenticator from './vanilla';
+import createEthSigAuthenticator from './ethSig';
 import * as utils from '../utils';
-import type { Authenticator } from '../types';
-
-const defaultAuthenticators = {
-  '0x05e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62': vanillaAuthenticator,
-  '0x064cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14': ethSigAuthenticator
-};
+import type { Authenticator, NetworkConfig } from '../types';
 
 export function getAuthenticator(
   address: string,
-  authenticators: any = defaultAuthenticators
+  networkConfig: NetworkConfig
 ): Authenticator | null {
-  const authenticator = authenticators[utils.encoding.hexPadLeft(address)];
+  const authenticator = networkConfig.authenticators[utils.encoding.hexPadLeft(address)];
   if (!authenticator) return null;
 
-  return authenticator;
+  if (authenticator.type === 'vanilla') {
+    return createVanillaAuthenticator();
+  }
+
+  if (authenticator.type === 'ethSig') {
+    return createEthSigAuthenticator();
+  }
+
+  return null;
 }

--- a/src/authenticators/vanilla.ts
+++ b/src/authenticators/vanilla.ts
@@ -1,21 +1,21 @@
 import type { Call } from 'starknet';
 import type { Authenticator, Envelope, VanillaProposeMessage, VanillaVoteMessage } from '../types';
 
-const vanillaAuthenticator: Authenticator = {
-  type: 'vanilla',
-  createCall(
-    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-    selector: string,
-    calldata: string[]
-  ): Call {
-    const { space, authenticator } = envelope.data.message;
+export default function createVanillaAuthenticator(): Authenticator {
+  return {
+    type: 'vanilla',
+    createCall(
+      envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+      selector: string,
+      calldata: string[]
+    ): Call {
+      const { space, authenticator } = envelope.data.message;
 
-    return {
-      contractAddress: authenticator,
-      entrypoint: 'authenticate',
-      calldata: [space, selector, calldata.length, ...calldata]
-    };
-  }
-};
-
-export default vanillaAuthenticator;
+      return {
+        contractAddress: authenticator,
+        entrypoint: 'authenticate',
+        calldata: [space, selector, calldata.length, ...calldata]
+      };
+    }
+  };
+}

--- a/src/clients/ethereum-sig/index.ts
+++ b/src/clients/ethereum-sig/index.ts
@@ -6,20 +6,25 @@ import { Wallet } from '@ethersproject/wallet';
 import fetch from 'cross-fetch';
 import { domain, proposeTypes, voteTypes } from './types';
 import * as utils from '../../utils';
-import {
+import { defaultNetwork } from '../../networks';
+import type {
   Propose,
   Vote,
   EthSigProposeMessage,
   EthSigVoteMessage,
   Envelope,
-  EthereumSigClientConfig
+  EthereumSigClientConfig,
+  EthereumSigClientOpts
 } from '../../types';
 
 export class EthereumSig {
   config: EthereumSigClientConfig;
 
-  constructor(config: EthereumSigClientConfig) {
-    this.config = config;
+  constructor(opts: EthereumSigClientOpts) {
+    this.config = {
+      networkConfig: defaultNetwork,
+      ...opts
+    };
   }
 
   generateSalt() {

--- a/src/clients/starknet-tx/index.ts
+++ b/src/clients/starknet-tx/index.ts
@@ -1,12 +1,14 @@
 import { Account, hash } from 'starknet';
 import * as utils from '../../utils';
 import { getAuthenticator } from '../../authenticators';
+import { defaultNetwork } from '../../networks';
 import type {
   EthSigProposeMessage,
   EthSigVoteMessage,
   VanillaVoteMessage,
   VanillaProposeMessage,
   Envelope,
+  ClientOpts,
   ClientConfig,
   StrategiesAddresses
 } from '../../types';
@@ -16,8 +18,11 @@ const { getSelectorFromName } = hash;
 export class StarkNetTx {
   config: ClientConfig;
 
-  constructor(config: ClientConfig) {
-    this.config = config;
+  constructor(opts: ClientOpts) {
+    this.config = {
+      networkConfig: defaultNetwork,
+      ...opts
+    };
   }
 
   async getProposeCalldata(
@@ -67,7 +72,10 @@ export class StarkNetTx {
     account: Account,
     envelope: Envelope<VanillaProposeMessage | EthSigProposeMessage>
   ) {
-    const authenticator = getAuthenticator(envelope.data.message.authenticator);
+    const authenticator = getAuthenticator(
+      envelope.data.message.authenticator,
+      this.config.networkConfig
+    );
     if (!authenticator) {
       throw new Error('Invalid authenticator');
     }
@@ -95,7 +103,10 @@ export class StarkNetTx {
   }
 
   async vote(account: Account, envelope: Envelope<VanillaVoteMessage | EthSigVoteMessage>) {
-    const authenticator = getAuthenticator(envelope.data.message.authenticator);
+    const authenticator = getAuthenticator(
+      envelope.data.message.authenticator,
+      this.config.networkConfig
+    );
     if (!authenticator) {
       throw new Error('Invalid authenticator');
     }

--- a/src/executors/ethRelayer.ts
+++ b/src/executors/ethRelayer.ts
@@ -1,24 +1,20 @@
 import { createExecutionHash, MetaTransaction } from '../utils/encoding/execution-hash';
 import { SplitUint256 } from '../utils/split-uint256';
+import { EthRelayerExecutionConfig } from '../types';
 
-const CONSTANTS = {
-  '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81': {
-    destination: '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
-    chainId: 5
-  }
-};
+export default function createEthRelayerExecutor(params: EthRelayerExecutionConfig['params']) {
+  const { destination, chainId } = params;
 
-export const ethRelayerExecutor = {
-  type: 'ethRelayer',
-  getExecutionData(executorAddress: keyof typeof CONSTANTS, transactions: MetaTransaction[]) {
-    const { destination, chainId } = CONSTANTS[executorAddress];
+  return {
+    type: 'ethRelayer',
+    getExecutionData(executorAddress: string, transactions: MetaTransaction[]) {
+      const { executionHash } = createExecutionHash(transactions, destination, chainId);
+      const executionHashSplit = SplitUint256.fromHex(executionHash);
 
-    const { executionHash } = createExecutionHash(transactions, destination, chainId);
-    const executionHashSplit = SplitUint256.fromHex(executionHash);
-
-    return {
-      executor: executorAddress,
-      executionParams: [destination, executionHashSplit.low, executionHashSplit.high]
-    };
-  }
-};
+      return {
+        executor: executorAddress,
+        executionParams: [destination, executionHashSplit.low, executionHashSplit.high]
+      };
+    }
+  };
+}

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -1,38 +1,30 @@
-import type { ExecutionInput } from '../types';
-import { ethRelayerExecutor } from './ethRelayer';
-import { starknetExecutor } from './starknet';
-import { vanillaExecutor } from './vanilla';
+import createStarknetExecutor from './starknet';
+import createVanillaExecutor from './vanilla';
+import createEthRelayerExecutor from './ethRelayer';
+import type { ExecutionInput, NetworkConfig } from '../types';
 
-type Executor = {
-  type: string;
-  getExecutionData(
-    executorAddress: string,
-    data?: any
-  ): {
-    executor: string;
-    executionParams: string[];
-  };
-};
-
-const executors: { [key: string]: Executor } = {
-  '1': starknetExecutor,
-  '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d': vanillaExecutor,
-  '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81': ethRelayerExecutor
-};
-
-export function getExecutionData(executorAddress: string, input?: ExecutionInput) {
-  const executor = executors[executorAddress];
+export function getExecutionData(
+  executorAddress: string,
+  networkConfig: NetworkConfig,
+  input?: ExecutionInput
+) {
+  const executor = networkConfig.executors[executorAddress];
   if (!executor) throw new Error(`Unknown executor ${executorAddress}`);
 
-  if (executor === starknetExecutor && input?.calls) {
-    return executor.getExecutionData(executorAddress, input.calls);
-  } else if (executor === ethRelayerExecutor && input?.transactions) {
-    return executor.getExecutionData(executorAddress, input.transactions);
-  } else if (executor === vanillaExecutor) {
-    return executor.getExecutionData(executorAddress);
+  if (executor.type === 'starknet' && input?.calls) {
+    return createStarknetExecutor().getExecutionData(executorAddress, input?.calls);
+  }
+
+  if (executor.type === 'ethRelayer' && input?.transactions) {
+    return createEthRelayerExecutor(executor.params).getExecutionData(
+      executorAddress,
+      input.transactions
+    );
+  }
+
+  if (executor.type === 'vanilla') {
+    return createVanillaExecutor().getExecutionData(executorAddress);
   }
 
   throw new Error(`Not enough data to create execution for executor ${executorAddress}`);
 }
-
-export { ethRelayerExecutor, starknetExecutor, vanillaExecutor };

--- a/src/executors/starknet.ts
+++ b/src/executors/starknet.ts
@@ -1,12 +1,14 @@
 import { createStarknetExecutionParams } from '../utils/encoding/starknet-execution-params';
 import type { Call } from 'starknet';
 
-export const starknetExecutor = {
-  type: 'starknet',
-  getExecutionData(executorAddress: string, calls: Call[]) {
-    return {
-      executor: executorAddress,
-      executionParams: createStarknetExecutionParams(calls)
-    };
-  }
-};
+export default function createStarknetExecutor() {
+  return {
+    type: 'starknet',
+    getExecutionData(executorAddress: string, calls: Call[]) {
+      return {
+        executor: executorAddress,
+        executionParams: createStarknetExecutionParams(calls)
+      };
+    }
+  };
+}

--- a/src/executors/vanilla.ts
+++ b/src/executors/vanilla.ts
@@ -1,9 +1,11 @@
-export const vanillaExecutor = {
-  type: 'vanilla',
-  getExecutionData(executorAddress: string) {
-    return {
-      executor: executorAddress,
-      executionParams: []
-    };
-  }
-};
+export default function createVanillaExecutor() {
+  return {
+    type: 'vanilla',
+    getExecutionData(executorAddress: string) {
+      return {
+        executor: executorAddress,
+        executionParams: []
+      };
+    }
+  };
+}

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,0 +1,43 @@
+import type { NetworkConfig } from './types';
+
+export const goerli2: NetworkConfig = {
+  authenticators: {
+    '0x05e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62': {
+      type: 'vanilla'
+    },
+    '0x064cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14': {
+      type: 'ethSig'
+    }
+  },
+  strategies: {
+    '0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48': {
+      type: 'vanilla'
+    },
+    '0x00d1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b': {
+      type: 'singleSlotProof',
+      params: {
+        fossilL1HeadersStoreAddress:
+          '0x69606dd1655fdbbf8189e88566c54890be8f7e4a3650398ac17f6586a4a336d',
+        fossilFactRegistryAddress:
+          '0x2e39818908f0da118fde6b88b52e4dbdf13d2e171e488507f40deb6811bde3f'
+      }
+    }
+  },
+  executors: {
+    '1': {
+      type: 'starknet'
+    },
+    '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d': {
+      type: 'vanilla'
+    },
+    '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81': {
+      type: 'ethRelayer',
+      params: {
+        destination: '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
+        chainId: 5
+      }
+    }
+  }
+};
+
+export const defaultNetwork = goerli2;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,16 +1,19 @@
-import vanillaStrategy from './vanilla';
-import singleSlotProofStrategy from './singleSlotProof';
+import createVanillaStrategy from './vanilla';
+import createSingleSlotProofStrategy from './singleSlotProof';
 import * as utils from '../utils';
-import type { Strategy } from '../types';
+import type { Strategy, NetworkConfig } from '../types';
 
-const defaultStrategies = {
-  '0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48': vanillaStrategy,
-  '0x00d1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b': singleSlotProofStrategy
-};
-
-export function getStrategy(address: string, strategies: any = defaultStrategies): Strategy | null {
-  const strategy = strategies[utils.encoding.hexPadLeft(address)];
+export function getStrategy(address: string, networkConfig: NetworkConfig): Strategy | null {
+  const strategy = networkConfig.strategies[utils.encoding.hexPadLeft(address)];
   if (!strategy) return null;
 
-  return strategy;
+  if (strategy.type === 'vanilla') {
+    return createVanillaStrategy();
+  }
+
+  if (strategy.type === 'singleSlotProof') {
+    return createSingleSlotProofStrategy(strategy.params);
+  }
+
+  return null;
 }

--- a/src/strategies/singleSlotProof.ts
+++ b/src/strategies/singleSlotProof.ts
@@ -1,18 +1,14 @@
 import { utils } from '..';
 import type { Call } from 'starknet';
+import { getStorageVarAddress, offsetStorageVar } from '../utils/encoding';
 import type {
+  SingleSlotProofStrategyConfig,
   ClientConfig,
   Envelope,
   Strategy,
   VanillaProposeMessage,
   VanillaVoteMessage
 } from '../types';
-import { getStorageVarAddress, offsetStorageVar } from '../utils/encoding';
-
-const fossilL1HeadersStoreAddress =
-  '0x69606dd1655fdbbf8189e88566c54890be8f7e4a3650398ac17f6586a4a336d';
-const fossilFactRegistryAddress =
-  '0x2e39818908f0da118fde6b88b52e4dbdf13d2e171e488507f40deb6811bde3f';
 
 const proposalRegistryStore = 'Voting_proposal_registry_store';
 const strategyParamsStore = 'Voting_voting_strategy_params_store';
@@ -21,153 +17,157 @@ const latestL1BlockStore = '_latest_l1_block';
 
 const snapshotTimestampsOffset = 2;
 
-async function fetchStrategyParams(
-  index: number,
-  envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-  clientConfig: ClientConfig
-): Promise<string[]> {
-  const lengthAddress = getStorageVarAddress(strategyParamsStore, index.toString(16), '0x0');
+export default function createSingleSlotProofStrategy(
+  params: SingleSlotProofStrategyConfig['params']
+): Strategy {
+  const { fossilL1HeadersStoreAddress, fossilFactRegistryAddress } = params;
 
-  const length = parseInt(
-    (await clientConfig.starkProvider.getStorageAt(
-      envelope.data.message.space,
-      lengthAddress
-    )) as string,
-    16
-  );
+  async function fetchStrategyParams(
+    index: number,
+    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+    clientConfig: ClientConfig
+  ): Promise<string[]> {
+    const lengthAddress = getStorageVarAddress(strategyParamsStore, index.toString(16), '0x0');
 
-  return Promise.all(
-    [...Array(length)].map(async (_, i) => {
-      const lengthAddress = getStorageVarAddress(
-        strategyParamsStore,
-        index.toString(16),
-        (i + 1).toString(16)
-      );
-
-      return clientConfig.starkProvider.getStorageAt(
+    const length = parseInt(
+      (await clientConfig.starkProvider.getStorageAt(
         envelope.data.message.space,
         lengthAddress
-      ) as Promise<string>;
-    })
-  );
-}
-
-async function getBlockStorage(
-  call: 'propose' | 'vote',
-  address: string,
-  envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-  clientConfig: ClientConfig
-): Promise<[string, string]> {
-  if (call === 'vote') {
-    const proposalAddress = getStorageVarAddress(
-      proposalRegistryStore,
-      (envelope as Envelope<VanillaVoteMessage>).data.message.proposal.toString(16)
+      )) as string,
+      16
     );
 
-    const timestamps = (await clientConfig.starkProvider.getStorageAt(
-      envelope.data.message.space,
-      offsetStorageVar(proposalAddress, snapshotTimestampsOffset)
-    )) as string;
+    return Promise.all(
+      [...Array(length)].map(async (_, i) => {
+        const lengthAddress = getStorageVarAddress(
+          strategyParamsStore,
+          index.toString(16),
+          (i + 1).toString(16)
+        );
 
-    const snapshotTimestamp = timestamps.replace('0x', '').slice(0, 8);
-
-    return [address, getStorageVarAddress(timestampToEthBlockNumberStore, snapshotTimestamp)];
+        return clientConfig.starkProvider.getStorageAt(
+          envelope.data.message.space,
+          lengthAddress
+        ) as Promise<string>;
+      })
+    );
   }
 
-  return [fossilL1HeadersStoreAddress, getStorageVarAddress(latestL1BlockStore)];
-}
+  async function getBlockStorage(
+    call: 'propose' | 'vote',
+    address: string,
+    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+    clientConfig: ClientConfig
+  ): Promise<[string, string]> {
+    if (call === 'vote') {
+      const proposalAddress = getStorageVarAddress(
+        proposalRegistryStore,
+        (envelope as Envelope<VanillaVoteMessage>).data.message.proposal.toString(16)
+      );
 
-async function fetchBlock(
-  call: 'propose' | 'vote',
-  address: string,
-  envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-  clientConfig: ClientConfig
-) {
-  const [contractAddress, key] = await getBlockStorage(call, address, envelope, clientConfig);
-  const block = parseInt(
-    (await clientConfig.starkProvider.getStorageAt(contractAddress, key)) as string,
-    16
-  );
+      const timestamps = (await clientConfig.starkProvider.getStorageAt(
+        envelope.data.message.space,
+        offsetStorageVar(proposalAddress, snapshotTimestampsOffset)
+      )) as string;
 
-  // 1 block offset due to
-  // https://github.com/snapshot-labs/sx-core/blob/e994394a7109de5527786cb99e981e132122fad4/contracts/starknet/VotingStrategies/SingleSlotProof.cairo#L60
-  return block - 1;
-}
+      const snapshotTimestamp = timestamps.replace('0x', '').slice(0, 8);
 
-async function fetchProofInputs(
-  call: 'propose' | 'vote',
-  address: string,
-  index: number,
-  envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-  clientConfig: ClientConfig
-) {
-  const [block, strategyParams] = await Promise.all([
-    fetchBlock(call, address, envelope, clientConfig),
-    fetchStrategyParams(index, envelope, clientConfig)
-  ]);
+      return [address, getStorageVarAddress(timestampToEthBlockNumberStore, snapshotTimestamp)];
+    }
 
-  const response = await fetch(clientConfig.ethUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'eth_getProof',
-      params: [
-        strategyParams[0],
-        [utils.encoding.getSlotKey(envelope.address, strategyParams[1])],
-        `0x${block.toString(16)}`
-      ]
-    })
-  });
+    return [fossilL1HeadersStoreAddress, getStorageVarAddress(latestL1BlockStore)];
+  }
 
-  const data = await response.json();
-  if (data.error) throw new Error('Failed to fetch proofs');
+  async function fetchBlock(
+    call: 'propose' | 'vote',
+    address: string,
+    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+    clientConfig: ClientConfig
+  ) {
+    const [contractAddress, key] = await getBlockStorage(call, address, envelope, clientConfig);
+    const block = parseInt(
+      (await clientConfig.starkProvider.getStorageAt(contractAddress, key)) as string,
+      16
+    );
 
-  return utils.storageProofs.getProofInputs(block, data.result);
-}
+    // 1 block offset due to
+    // https://github.com/snapshot-labs/sx-core/blob/e994394a7109de5527786cb99e981e132122fad4/contracts/starknet/VotingStrategies/SingleSlotProof.cairo#L60
+    return block - 1;
+  }
 
-const singleSlotProofStrategy: Strategy = {
-  type: 'singleSlotProof',
-  async getParams(
+  async function fetchProofInputs(
     call: 'propose' | 'vote',
     address: string,
     index: number,
     envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
     clientConfig: ClientConfig
-  ): Promise<string[]> {
-    const proofInputs = await fetchProofInputs(call, address, index, envelope, clientConfig);
+  ) {
+    const [block, strategyParams] = await Promise.all([
+      fetchBlock(call, address, envelope, clientConfig),
+      fetchStrategyParams(index, envelope, clientConfig)
+    ]);
 
-    return proofInputs.storageProofs[0];
-  },
-  async getExtraProposeCalls(
-    address: string,
-    index: number,
-    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-    clientConfig: ClientConfig
-  ): Promise<Call[]> {
-    const proofInputs = await fetchProofInputs('propose', address, index, envelope, clientConfig);
-
-    return [
-      {
-        contractAddress: fossilFactRegistryAddress,
-        entrypoint: 'prove_account',
-        calldata: [
-          proofInputs.accountOptions,
-          proofInputs.blockNumber,
-          proofInputs.ethAddress.values[0],
-          proofInputs.ethAddress.values[1],
-          proofInputs.ethAddress.values[2],
-          proofInputs.accountProofSizesBytes.length,
-          ...proofInputs.accountProofSizesBytes,
-          proofInputs.accountProofSizesWords.length,
-          ...proofInputs.accountProofSizesWords,
-          proofInputs.accountProof.length,
-          ...proofInputs.accountProof
+    const response = await fetch(clientConfig.ethUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getProof',
+        params: [
+          strategyParams[0],
+          [utils.encoding.getSlotKey(envelope.address, strategyParams[1])],
+          `0x${block.toString(16)}`
         ]
-      }
-    ];
-  }
-};
+      })
+    });
 
-export default singleSlotProofStrategy;
+    const data = await response.json();
+    if (data.error) throw new Error('Failed to fetch proofs');
+
+    return utils.storageProofs.getProofInputs(block, data.result);
+  }
+
+  return {
+    type: 'singleSlotProof',
+    async getParams(
+      call: 'propose' | 'vote',
+      address: string,
+      index: number,
+      envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+      clientConfig: ClientConfig
+    ): Promise<string[]> {
+      const proofInputs = await fetchProofInputs(call, address, index, envelope, clientConfig);
+
+      return proofInputs.storageProofs[0];
+    },
+    async getExtraProposeCalls(
+      address: string,
+      index: number,
+      envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+      clientConfig: ClientConfig
+    ): Promise<Call[]> {
+      const proofInputs = await fetchProofInputs('propose', address, index, envelope, clientConfig);
+
+      return [
+        {
+          contractAddress: fossilFactRegistryAddress,
+          entrypoint: 'prove_account',
+          calldata: [
+            proofInputs.accountOptions,
+            proofInputs.blockNumber,
+            proofInputs.ethAddress.values[0],
+            proofInputs.ethAddress.values[1],
+            proofInputs.ethAddress.values[2],
+            proofInputs.accountProofSizesBytes.length,
+            ...proofInputs.accountProofSizesBytes,
+            proofInputs.accountProofSizesWords.length,
+            ...proofInputs.accountProofSizesWords,
+            proofInputs.accountProof.length,
+            ...proofInputs.accountProof
+          ]
+        }
+      ];
+    }
+  };
+}

--- a/src/strategies/vanilla.ts
+++ b/src/strategies/vanilla.ts
@@ -2,6 +2,7 @@
 
 import type { Call } from 'starknet';
 import type {
+  VanillaStrategyConfig,
   ClientConfig,
   Envelope,
   Strategy,
@@ -9,25 +10,25 @@ import type {
   VanillaVoteMessage
 } from '../types';
 
-const vanillaStrategy: Strategy = {
-  type: 'vanilla',
-  async getParams(
-    call: 'propose' | 'vote',
-    address: string,
-    index: number,
-    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-    clientConfig: ClientConfig
-  ): Promise<string[]> {
-    return [];
-  },
-  async getExtraProposeCalls(
-    address: string,
-    index: number,
-    envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
-    clientConfig: ClientConfig
-  ): Promise<Call[]> {
-    return [];
-  }
-};
-
-export default vanillaStrategy;
+export default function createVanillaStrategy(): Strategy {
+  return {
+    type: 'vanilla',
+    async getParams(
+      call: 'propose' | 'vote',
+      address: string,
+      index: number,
+      envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+      clientConfig: ClientConfig
+    ): Promise<string[]> {
+      return [];
+    },
+    async getExtraProposeCalls(
+      address: string,
+      index: number,
+      envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,
+      clientConfig: ClientConfig
+    ): Promise<Call[]> {
+      return [];
+    }
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,10 @@
 import type { Provider } from 'starknet';
 import type { Call } from 'starknet';
-import type { Choice } from './utils/choice';
-import type { MetaTransaction } from './utils/encoding/execution-hash';
+import type { Choice } from '../utils/choice';
+import type { MetaTransaction } from '../utils/encoding/execution-hash';
+import type { NetworkConfig } from './networkConfig';
+
+export * from './networkConfig';
 
 export interface Authenticator {
   type: string;
@@ -25,9 +28,20 @@ export interface Strategy {
   ): Promise<Call[]>;
 }
 
+export type ClientOpts = {
+  ethUrl: string;
+  starkProvider: Provider;
+  networkConfig?: NetworkConfig;
+};
+
 export type ClientConfig = {
   ethUrl: string;
   starkProvider: Provider;
+  networkConfig: NetworkConfig;
+};
+
+export type EthereumSigClientOpts = ClientOpts & {
+  manaUrl: string;
 };
 
 export type EthereumSigClientConfig = ClientConfig & {

--- a/src/types/networkConfig.ts
+++ b/src/types/networkConfig.ts
@@ -1,0 +1,49 @@
+export type VanillaAuthenticatorConfig = {
+  type: 'vanilla';
+};
+
+export type EthSigAuthenticatorConfig = {
+  type: 'ethSig';
+};
+
+export type VanillaStrategyConfig = {
+  type: 'vanilla';
+};
+
+export type SingleSlotProofStrategyConfig = {
+  type: 'singleSlotProof';
+  params: {
+    fossilL1HeadersStoreAddress: string;
+    fossilFactRegistryAddress: string;
+  };
+};
+
+export type StarknetExecutionConfig = {
+  type: 'starknet';
+};
+
+export type VanillaExecutionConfig = {
+  type: 'vanilla';
+};
+
+export type EthRelayerExecutionConfig = {
+  type: 'ethRelayer';
+  params: {
+    destination: string;
+    chainId: number;
+  };
+};
+
+export type NetworkConfig = {
+  authenticators: {
+    [key: string]: VanillaAuthenticatorConfig | EthSigAuthenticatorConfig | undefined;
+  };
+  strategies: { [key: string]: VanillaStrategyConfig | SingleSlotProofStrategyConfig | undefined };
+  executors: {
+    [key: string]:
+      | StarknetExecutionConfig
+      | VanillaExecutionConfig
+      | EthRelayerExecutionConfig
+      | undefined;
+  };
+};

--- a/src/utils/strategies.ts
+++ b/src/utils/strategies.ts
@@ -31,7 +31,7 @@ export async function getStrategiesParams(
 ) {
   return Promise.all(
     strategies.map(strategyData => {
-      const strategy = getStrategy(strategyData.address);
+      const strategy = getStrategy(strategyData.address, config.networkConfig);
       if (!strategy) throw new Error('Invalid strategy');
 
       return strategy.getParams(
@@ -59,7 +59,7 @@ export async function getExtraProposeCalls(
 ) {
   const extraCalls = await Promise.all(
     strategies.map(strategyData => {
-      const strategy = getStrategy(strategyData.address);
+      const strategy = getStrategy(strategyData.address, config.networkConfig);
       if (!strategy) throw new Error('Invalid strategy');
 
       return strategy.getExtraProposeCalls(

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -3,6 +3,7 @@ import { getExecutionData } from '../../src/executors';
 import { Account, Provider, ec, constants } from 'starknet';
 import { Wallet } from '@ethersproject/wallet';
 import { Choice } from '../../src/utils/choice';
+import { defaultNetwork } from '../../src/networks';
 
 describe('StarkNetTx', () => {
   expect(process.env.STARKNET_ADDRESS).toBeDefined();
@@ -191,7 +192,7 @@ describe('StarkNetTx', () => {
     ];
 
     it('StarkNetTx.propose()', async () => {
-      const executionData = getExecutionData(executorAddress, { transactions });
+      const executionData = getExecutionData(executorAddress, defaultNetwork, { transactions });
 
       const envelope = {
         address: walletAddress,

--- a/test/unit/authenticators/ethSig.test.ts
+++ b/test/unit/authenticators/ethSig.test.ts
@@ -1,8 +1,10 @@
 import { hash } from 'starknet';
-import ethSigAuthenticator from '../../../src/authenticators/ethSig';
+import createEthSigAuthenticator from '../../../src/authenticators/ethSig';
 import { proposeEnvelope } from '../fixtures';
 
 describe('ethSigAuthenticator', () => {
+  const ethSigAuthenticator = createEthSigAuthenticator();
+
   it('should return type', () => {
     expect(ethSigAuthenticator.type).toBe('ethSig');
   });

--- a/test/unit/authenticators/index.test.ts
+++ b/test/unit/authenticators/index.test.ts
@@ -1,43 +1,22 @@
 import { getAuthenticator } from '../../../src/authenticators';
-import vanillaAuthenticator from '../../../src/authenticators/vanilla';
-import ethSigAuthenticator from '../../../src/authenticators/ethSig';
+import { defaultNetwork } from '../../../src/networks';
 
 describe('authenticators', () => {
   describe('getAuthenticator', () => {
     it('should return correct authenticator from predefined default addresses', () => {
       expect(
-        getAuthenticator('0x05e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62')?.type
-      ).toBe('vanilla');
-
-      expect(
-        getAuthenticator('0x064cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14')?.type
-      ).toBe('ethSig');
-    });
-
-    it('should return correct authenticator from supplied addresses', () => {
-      const authenticators = {
-        '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922': vanillaAuthenticator,
-        '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9': ethSigAuthenticator
-      };
-      expect(
         getAuthenticator(
-          '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922',
-          authenticators
+          '0x05e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62',
+          defaultNetwork
         )?.type
       ).toBe('vanilla');
 
       expect(
         getAuthenticator(
-          '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9',
-          authenticators
+          '0x064cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14',
+          defaultNetwork
         )?.type
       ).toBe('ethSig');
-    });
-
-    it('should return null for unknown authenticators', () => {
-      expect(
-        getAuthenticator('0x000000000000000000000000000000000000000000000000000000000000000')
-      ).toBe(null);
     });
   });
 });

--- a/test/unit/authenticators/vanilla.test.ts
+++ b/test/unit/authenticators/vanilla.test.ts
@@ -1,8 +1,10 @@
 import { hash } from 'starknet';
-import vanillaAuthenticator from '../../../src/authenticators/vanilla';
+import createVanillaAuthenticator from '../../../src/authenticators/vanilla';
 import { proposeEnvelope } from '../fixtures';
 
 describe('vanillaAuthenticator', () => {
+  const vanillaAuthenticator = createVanillaAuthenticator();
+
   it('should return type', () => {
     expect(vanillaAuthenticator.type).toBe('vanilla');
   });

--- a/test/unit/executors/ethRelayer.test.ts
+++ b/test/unit/executors/ethRelayer.test.ts
@@ -1,6 +1,11 @@
-import { ethRelayerExecutor } from '../../../src/executors';
+import createEthRelayerExecutor from '../../../src/executors/ethRelayer';
 
 describe('ethRelayerExecutor', () => {
+  const ethRelayerExecutor = createEthRelayerExecutor({
+    destination: '0xa88f72e92cc519d617b684F8A78d3532E7bb61ca',
+    chainId: 5
+  });
+
   const address = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
   const txs = [
     {

--- a/test/unit/executors/index.test.ts
+++ b/test/unit/executors/index.test.ts
@@ -1,10 +1,11 @@
 import { getExecutionData } from '../../../src/executors';
+import { defaultNetwork } from '../../../src/networks';
 
 describe('getExecutionData', () => {
   it('should create vanilla execution data', () => {
     const address = '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d';
 
-    const data = getExecutionData(address);
+    const data = getExecutionData(address, defaultNetwork);
 
     expect(data).toEqual({
       executor: address,
@@ -21,7 +22,7 @@ describe('getExecutionData', () => {
       }
     ];
 
-    const data = getExecutionData('1', { calls });
+    const data = getExecutionData('1', defaultNetwork, { calls });
 
     expect(data).toEqual({
       executor: '1',
@@ -48,7 +49,7 @@ describe('getExecutionData', () => {
       }
     ];
 
-    const data = getExecutionData(address, { transactions });
+    const data = getExecutionData(address, defaultNetwork, { transactions });
 
     expect(data).toEqual({
       executor: address,
@@ -63,7 +64,7 @@ describe('getExecutionData', () => {
   it('should throw if contract is unknown', () => {
     const address = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-    expect(() => getExecutionData(address)).toThrowError(
+    expect(() => getExecutionData(address, defaultNetwork)).toThrowError(
       'Unknown executor 0x0000000000000000000000000000000000000000000000000000000000000000'
     );
   });
@@ -71,7 +72,7 @@ describe('getExecutionData', () => {
   it('should throw if inputs are missing', () => {
     const address = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
 
-    expect(() => getExecutionData(address)).toThrowError(
+    expect(() => getExecutionData(address, defaultNetwork)).toThrowError(
       'Not enough data to create execution for executor 0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81'
     );
   });

--- a/test/unit/executors/starknet.test.ts
+++ b/test/unit/executors/starknet.test.ts
@@ -1,6 +1,8 @@
-import { starknetExecutor } from '../../../src/executors';
+import createStarknetExecutor from '../../../src/executors/starknet';
 
 describe('starknetExecutor', () => {
+  const starknetExecutor = createStarknetExecutor();
+
   const calls = [
     {
       contractAddress: '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',

--- a/test/unit/executors/vanilla.test.ts
+++ b/test/unit/executors/vanilla.test.ts
@@ -1,6 +1,8 @@
-import { vanillaExecutor } from '../../../src/executors';
+import createVanillaExecutor from '../../../src/executors/vanilla';
 
 describe('vanillaExecutor', () => {
+  const vanillaExecutor = createVanillaExecutor();
+
   const address = '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d';
 
   it('should create execution data', () => {

--- a/test/unit/strategies/index.test.ts
+++ b/test/unit/strategies/index.test.ts
@@ -1,44 +1,24 @@
 import { getStrategy } from '../../../src/strategies';
 import vanillaStrategy from '../../../src/strategies/vanilla';
 import singleSlotProofStrategy from '../../../src/strategies/singleSlotProof';
+import { defaultNetwork } from '../../../src/networks';
 
 describe('voting strategies', () => {
   describe('getStrategy', () => {
     it('should return correct strategy from predefined default addresses', () => {
       expect(
-        getStrategy('0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48')?.type
-      ).toBe('vanilla');
-
-      expect(
-        getStrategy('0x00d1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b')?.type
-      ).toBe('singleSlotProof');
-    });
-
-    it('should return correct strategy from supplied addresses', () => {
-      const strategies = {
-        '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922': vanillaStrategy,
-        '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9':
-          singleSlotProofStrategy
-      };
-      expect(
         getStrategy(
-          '0x91469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd922',
-          strategies
+          '0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48',
+          defaultNetwork
         )?.type
       ).toBe('vanilla');
 
       expect(
         getStrategy(
-          '0x0091469387a06fb88dd66559f4bc91e4c0c1e61e65c259b14a4d43f274fdabd9',
-          strategies
+          '0x00d1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
+          defaultNetwork
         )?.type
       ).toBe('singleSlotProof');
-    });
-
-    it('should return null for unknown strategies', () => {
-      expect(getStrategy('0x000000000000000000000000000000000000000000000000000000000000000')).toBe(
-        null
-      );
     });
   });
 });

--- a/test/unit/strategies/singleSlotProof.test.ts
+++ b/test/unit/strategies/singleSlotProof.test.ts
@@ -1,5 +1,6 @@
 import { defaultProvider } from 'starknet';
-import singleSlotProofStrategy from '../../../src/strategies/singleSlotProof';
+import createSingleSlotProofStrategy from '../../../src/strategies/singleSlotProof';
+import { defaultNetwork } from '../../../src/networks';
 import { getStorageVarAddress } from '../../../src/utils/encoding';
 import { proposeEnvelope, voteEnvelope } from '../fixtures';
 
@@ -9,6 +10,13 @@ const starkProvider = defaultProvider;
 const latestL1Block = 8050780;
 
 describe('singleSlotProofStrategy', () => {
+  const singleSlotProofStrategy = createSingleSlotProofStrategy({
+    fossilL1HeadersStoreAddress:
+      '0x69606dd1655fdbbf8189e88566c54890be8f7e4a3650398ac17f6586a4a336d',
+    fossilFactRegistryAddress: '0x2e39818908f0da118fde6b88b52e4dbdf13d2e171e488507f40deb6811bde3f'
+  });
+  const config = { starkProvider, ethUrl, networkConfig: defaultNetwork };
+
   let getStorageAtSpy;
   beforeAll(() => {
     const getStorageAt = starkProvider.getStorageAt;
@@ -41,7 +49,7 @@ describe('singleSlotProofStrategy', () => {
       '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
       1,
       voteEnvelope,
-      { ethUrl, starkProvider }
+      config
     );
 
     expect(params).toMatchSnapshot();
@@ -53,7 +61,7 @@ describe('singleSlotProofStrategy', () => {
       '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
       1,
       proposeEnvelope,
-      { ethUrl, starkProvider }
+      config
     );
 
     expect(params).toMatchSnapshot();
@@ -64,7 +72,7 @@ describe('singleSlotProofStrategy', () => {
       '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
       1,
       proposeEnvelope,
-      { ethUrl, starkProvider }
+      config
     );
 
     expect(params).toMatchSnapshot();

--- a/test/unit/strategies/vanilla.test.ts
+++ b/test/unit/strategies/vanilla.test.ts
@@ -1,11 +1,15 @@
 import { defaultProvider } from 'starknet';
-import vanillaStrategy from '../../../src/strategies/vanilla';
+import createVanillaStrategy from '../../../src/strategies/vanilla';
+import { defaultNetwork } from '../../../src/networks';
 import { proposeEnvelope } from '../fixtures';
 
 const ethUrl = process.env.GOERLI_NODE_URL as string;
 const starkProvider = defaultProvider;
 
 describe('vanillaStrategy', () => {
+  const vanillaStrategy = createVanillaStrategy();
+  const config = { starkProvider, ethUrl, networkConfig: defaultNetwork };
+
   it('should return type', () => {
     expect(vanillaStrategy.type).toBe('vanilla');
   });
@@ -16,7 +20,7 @@ describe('vanillaStrategy', () => {
       '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
       0,
       proposeEnvelope,
-      { ethUrl, starkProvider }
+      config
     );
 
     expect(params).toEqual([]);
@@ -27,7 +31,7 @@ describe('vanillaStrategy', () => {
       '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
       0,
       proposeEnvelope,
-      { ethUrl, starkProvider }
+      config
     );
 
     expect(params).toEqual([]);


### PR DESCRIPTION
## Summary

This PR makes all authenticators/strategies/executors configurable at runtime (including their own configs as well).

Closes https://github.com/snapshot-labs/sx.js/issues/106

## Test plan
 - Create proposal via `yarn test:integration` by selecting testcase with `.only`.