### PR TITLE
chore: export networks and types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * as clients from './clients';
 export * as utils from './utils';
 export { getExecutionData } from './executors';
+export * from './networks';
+export * from './types';


### PR DESCRIPTION
## Summary

This way we won't need to drill files from `dist`.