### PR TITLE
refactor: remove import cycles

### DIFF
--- a/src/authenticators/ethSig.ts
+++ b/src/authenticators/ethSig.ts
@@ -1,4 +1,5 @@
-import * as utils from '../utils';
+import { getRSVFromSig } from '../utils/encoding';
+import { SplitUint256 } from '../utils/split-uint256';
 import type { Call } from 'starknet';
 import type { Authenticator, Envelope, EthSigProposeMessage, EthSigVoteMessage } from '../types';
 
@@ -12,8 +13,8 @@ export default function createEthSigAuthenticator(): Authenticator {
     ): Call {
       const { sig, data } = envelope;
       const { space, authenticator, salt } = data.message;
-      const { r, s, v } = utils.encoding.getRSVFromSig(sig);
-      const rawSalt = utils.splitUint256.SplitUint256.fromHex(`0x${salt.toString(16)}`);
+      const { r, s, v } = getRSVFromSig(sig);
+      const rawSalt = SplitUint256.fromHex(`0x${salt.toString(16)}`);
 
       return {
         contractAddress: authenticator,

--- a/src/authenticators/index.ts
+++ b/src/authenticators/index.ts
@@ -1,13 +1,13 @@
 import createVanillaAuthenticator from './vanilla';
 import createEthSigAuthenticator from './ethSig';
-import * as utils from '../utils';
+import { hexPadLeft } from '../utils/encoding';
 import type { Authenticator, NetworkConfig } from '../types';
 
 export function getAuthenticator(
   address: string,
   networkConfig: NetworkConfig
 ): Authenticator | null {
-  const authenticator = networkConfig.authenticators[utils.encoding.hexPadLeft(address)];
+  const authenticator = networkConfig.authenticators[hexPadLeft(address)];
   if (!authenticator) return null;
 
   if (authenticator.type === 'vanilla') {

--- a/src/clients/zodiac/index.ts
+++ b/src/clients/zodiac/index.ts
@@ -1,11 +1,11 @@
 import { Interface } from '@ethersproject/abi';
 import { Contract } from '@ethersproject/contracts';
 import { Wallet } from '@ethersproject/wallet';
-import { createExecutionHash } from '../../utils/encoding/execution-hash';
+import { createExecutionHash } from '../../utils/encoding';
 import { SplitUint256 } from '../../utils/split-uint256';
 import { defaultNetwork } from '../../networks';
 import ZodiacAbi from './abis/zodiac.json';
-import type { MetaTransaction } from '../../utils/encoding/execution-hash';
+import type { MetaTransaction } from '../../utils/encoding';
 import type { ExecutionInput, NetworkConfig } from '../../types';
 
 export class Zodiac {

--- a/src/executors/ethRelayer.ts
+++ b/src/executors/ethRelayer.ts
@@ -1,4 +1,4 @@
-import { createExecutionHash, MetaTransaction } from '../utils/encoding/execution-hash';
+import { createExecutionHash, MetaTransaction } from '../utils/encoding';
 import { SplitUint256 } from '../utils/split-uint256';
 import { EthRelayerExecutionConfig } from '../types';
 

--- a/src/executors/starknet.ts
+++ b/src/executors/starknet.ts
@@ -1,4 +1,4 @@
-import { createStarknetExecutionParams } from '../utils/encoding/starknet-execution-params';
+import { createStarknetExecutionParams } from '../utils/encoding';
 import type { Call } from 'starknet';
 
 export default function createStarknetExecutor() {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,10 +1,10 @@
 import createVanillaStrategy from './vanilla';
 import createSingleSlotProofStrategy from './singleSlotProof';
-import * as utils from '../utils';
+import { hexPadLeft } from '../utils/encoding';
 import type { Strategy, NetworkConfig } from '../types';
 
 export function getStrategy(address: string, networkConfig: NetworkConfig): Strategy | null {
-  const strategy = networkConfig.strategies[utils.encoding.hexPadLeft(address)];
+  const strategy = networkConfig.strategies[hexPadLeft(address)];
   if (!strategy) return null;
 
   if (strategy.type === 'vanilla') {

--- a/src/strategies/singleSlotProof.ts
+++ b/src/strategies/singleSlotProof.ts
@@ -1,6 +1,6 @@
-import { utils } from '..';
 import type { Call } from 'starknet';
-import { getStorageVarAddress, offsetStorageVar } from '../utils/encoding';
+import { getProofInputs } from '../utils/storage-proofs';
+import { getStorageVarAddress, offsetStorageVar, getSlotKey } from '../utils/encoding';
 import type {
   SingleSlotProofStrategyConfig,
   ClientConfig,
@@ -116,7 +116,7 @@ export default function createSingleSlotProofStrategy(
         method: 'eth_getProof',
         params: [
           strategyParams[0],
-          [utils.encoding.getSlotKey(envelope.address, strategyParams[1])],
+          [getSlotKey(envelope.address, strategyParams[1])],
           `0x${block.toString(16)}`
         ]
       })
@@ -125,7 +125,7 @@ export default function createSingleSlotProofStrategy(
     const data = await response.json();
     if (data.error) throw new Error('Failed to fetch proofs');
 
-    return utils.storageProofs.getProofInputs(block, data.result);
+    return getProofInputs(block, data.result);
   }
 
   return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import type { Provider } from 'starknet';
 import type { Call } from 'starknet';
 import type { Choice } from '../utils/choice';
-import type { MetaTransaction } from '../utils/encoding/execution-hash';
+import type { MetaTransaction } from '../utils/encoding';
 import type { NetworkConfig } from './networkConfig';
 
 export * from './networkConfig';

--- a/src/utils/strategies.ts
+++ b/src/utils/strategies.ts
@@ -1,5 +1,5 @@
 import { getStrategy } from '../strategies';
-import * as utils from '../utils';
+import { getStorageVarAddress } from '../utils/encoding';
 import type { Propose, Vote, ClientConfig, StrategiesAddresses } from '../types';
 
 export async function getStrategies(
@@ -11,7 +11,7 @@ export async function getStrategies(
       id =>
         config.starkProvider.getStorageAt(
           data.space,
-          utils.encoding.getStorageVarAddress('Voting_voting_strategies_store', id.toString(16))
+          getStorageVarAddress('Voting_voting_strategies_store', id.toString(16))
         ) as Promise<string>
     )
   );


### PR DESCRIPTION
## Summary

Because of import cycles production build of sx-ui is currently broken because Vite can't build the tree properly (right now you can't propose on testnet.snapshotx.xyz). This PR removes import cycles by stopping global `utils` import to solve this issue.

## Test plan

Run:
```bash
madge --circular --ts-config ./tsconfig.json --extensions ts ./src/
```

No circular dependencies should be found.