### PR TITLE
refactor: accept Signer instead of Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ethereumjs/block": "^3.6.3",
     "@ethereumjs/common": "^2.6.5",
     "@ethersproject/abi": "^5.7.0",
+    "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/hash": "^5.6.1",
     "@ethersproject/keccak256": "^5.7.0",

--- a/src/clients/zodiac/index.ts
+++ b/src/clients/zodiac/index.ts
@@ -1,6 +1,6 @@
 import { Interface } from '@ethersproject/abi';
+import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
-import { Wallet } from '@ethersproject/wallet';
 import { createExecutionHash } from '../../utils/encoding';
 import { SplitUint256 } from '../../utils/split-uint256';
 import { defaultNetwork } from '../../networks';
@@ -9,11 +9,11 @@ import type { MetaTransaction } from '../../utils/encoding';
 import type { ExecutionInput, NetworkConfig } from '../../types';
 
 export class Zodiac {
-  config: { networkConfig: NetworkConfig; wallet: Wallet };
+  config: { networkConfig: NetworkConfig; signer: Signer };
 
   zodiacInterface: Interface;
 
-  constructor(opts: { networkConfig?: NetworkConfig; wallet: Wallet }) {
+  constructor(opts: { networkConfig?: NetworkConfig; signer: Signer }) {
     this.config = {
       networkConfig: defaultNetwork,
       ...opts
@@ -30,7 +30,7 @@ export class Zodiac {
 
     const { destination, chainId } = executorConfig.params;
 
-    const zodiacModule = new Contract(destination, this.zodiacInterface, this.config.wallet);
+    const zodiacModule = new Contract(destination, this.zodiacInterface, this.config.signer);
 
     const { executionHash, txHashes } = createExecutionHash(
       input.transactions,
@@ -56,7 +56,7 @@ export class Zodiac {
 
     const { destination } = executorConfig.params;
 
-    const zodiacModule = new Contract(destination, this.zodiacInterface, this.config.wallet);
+    const zodiacModule = new Contract(destination, this.zodiacInterface, this.config.signer);
 
     return zodiacModule.executeProposalTx(
       proposalIndex,

--- a/test/integration/spaceManager.test.ts
+++ b/test/integration/spaceManager.test.ts
@@ -23,7 +23,7 @@ describe('SpaceManager', () => {
 
   it('should finalizeProposal', async () => {
     const space = '0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28';
-    const proposalId = 26;
+    const proposalId = 52;
     const executor = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
 
     const transactions = [

--- a/test/integration/zodiac.test.ts
+++ b/test/integration/zodiac.test.ts
@@ -7,7 +7,7 @@ describe('Zodiac', () => {
   expect(process.env.ETH_PK).toBeDefined();
 
   const provider = new JsonRpcProvider(process.env.GOERLI_NODE_URL);
-  const wallet = new Wallet(process.env.ETH_PK as string, provider);
+  const signer = new Wallet(process.env.ETH_PK as string, provider);
   const space = '0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28';
   const executor = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
   const transactions = [
@@ -20,7 +20,7 @@ describe('Zodiac', () => {
     }
   ];
 
-  const zodiac = new Zodiac({ wallet });
+  const zodiac = new Zodiac({ signer });
 
   it('should receiveProposal', async () => {
     const receipt = await zodiac.receiveProposal(space, executor, {


### PR DESCRIPTION
## Summary

Depends on https://github.com/snapshot-labs/sx.js/pull/118

Wallet is too complex to require, we can do with just signer.