### PR TITLE
feat(starknet): only prove account when needed

### DIFF
--- a/src/clients/starknet/starknet-tx/index.ts
+++ b/src/clients/starknet/starknet-tx/index.ts
@@ -1,11 +1,7 @@
 import { Account, hash } from 'starknet';
 import { IntsSequence } from '../../../utils/ints-sequence';
 import { getVoteCalldata, getProposeCalldata } from '../../../utils/encoding';
-import {
-  getStrategies,
-  getStrategiesParams,
-  getExtraProposeCalls
-} from '../../../utils/strategies';
+import { getStrategies, getStrategiesParams, getExtraCalls } from '../../../utils/strategies';
 import { getAuthenticator } from '../../../authenticators';
 import { defaultNetwork } from '../../../networks';
 import type {
@@ -90,7 +86,8 @@ export class StarkNetTx {
 
     const calldata = await this.getProposeCalldata(strategiesAddresses, envelope);
     const call = authenticator.createCall(envelope, getSelectorFromName('propose'), calldata);
-    const extraCalls = await getExtraProposeCalls(
+    const extraCalls = await getExtraCalls(
+      'propose',
       strategiesAddresses,
       envelope.address,
       envelope.data.message,
@@ -117,6 +114,13 @@ export class StarkNetTx {
     const strategiesAddresses = await getStrategies(envelope.data.message, this.config);
     const calldata = await this.getVoteCalldata(strategiesAddresses, envelope);
     const call = authenticator.createCall(envelope, getSelectorFromName('vote'), calldata);
+    const extraCalls = await getExtraCalls(
+      'vote',
+      strategiesAddresses,
+      envelope.address,
+      envelope.data.message,
+      this.config
+    );
 
     const fee = await account.estimateFee(call);
     return account.execute(call, undefined, {

--- a/src/strategies/vanilla.ts
+++ b/src/strategies/vanilla.ts
@@ -22,7 +22,8 @@ export default function createVanillaStrategy(): Strategy {
     ): Promise<string[]> {
       return [];
     },
-    async getExtraProposeCalls(
+    async getExtraCalls(
+      call: 'propose' | 'vote',
       address: string,
       index: number,
       envelope: Envelope<VanillaProposeMessage | VanillaVoteMessage>,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,8 @@ export interface Strategy {
     envelope: Envelope<Message>,
     clientConfig: ClientConfig
   ): Promise<string[]>;
-  getExtraProposeCalls(
+  getExtraCalls(
+    call: 'propose' | 'vote',
     address: string,
     index: number,
     envelope: Envelope<Message>,

--- a/src/utils/strategies.ts
+++ b/src/utils/strategies.ts
@@ -51,10 +51,11 @@ export async function getStrategiesParams(
   );
 }
 
-export async function getExtraProposeCalls(
+export async function getExtraCalls(
+  call: 'propose' | 'vote',
   strategies: StrategiesAddresses,
   address: string,
-  data: Propose,
+  data: Propose | Vote,
   config: ClientConfig
 ) {
   const extraCalls = await Promise.all(
@@ -62,7 +63,8 @@ export async function getExtraProposeCalls(
       const strategy = getStrategy(strategyData.address, config.networkConfig);
       if (!strategy) throw new Error('Invalid strategy');
 
-      return strategy.getExtraProposeCalls(
+      return strategy.getExtraCalls(
+        call,
         address,
         strategyData.index,
         {

--- a/test/unit/strategies/__snapshots__/singleSlotProof.test.ts.snap
+++ b/test/unit/strategies/__snapshots__/singleSlotProof.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`singleSlotProofStrategy should return empty extra propose calls if already proven 1`] = `[]`;
+
 exports[`singleSlotProofStrategy should return extra propose calls 1`] = `
 [
   {

--- a/test/unit/strategies/singleSlotProof.test.ts
+++ b/test/unit/strategies/singleSlotProof.test.ts
@@ -10,6 +10,8 @@ const starkProvider = defaultProvider;
 const latestL1Block = 8050780;
 
 describe('singleSlotProofStrategy', () => {
+  let mockStorageHash = '0x0';
+
   const singleSlotProofStrategy = createSingleSlotProofStrategy({
     fossilL1HeadersStoreAddress:
       '0x69606dd1655fdbbf8189e88566c54890be8f7e4a3650398ac17f6586a4a336d',
@@ -31,8 +33,19 @@ describe('singleSlotProofStrategy', () => {
           return Promise.resolve(latestL1Block.toString(16));
         }
 
+        if (
+          contractAddress === '0x2e39818908f0da118fde6b88b52e4dbdf13d2e171e488507f40deb6811bde3f' &&
+          key === '2842026109080255012094360634329872566622008440026082802794951354329726168434'
+        ) {
+          return Promise.resolve(mockStorageHash);
+        }
+
         return getStorageAt.call(starkProvider, contractAddress, key);
       });
+  });
+
+  beforeEach(() => {
+    mockStorageHash = '0x0';
   });
 
   afterAll(() => {
@@ -68,7 +81,22 @@ describe('singleSlotProofStrategy', () => {
   });
 
   it('should return extra propose calls', async () => {
-    const params = await singleSlotProofStrategy.getExtraProposeCalls(
+    const params = await singleSlotProofStrategy.getExtraCalls(
+      'propose',
+      '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
+      1,
+      proposeEnvelope,
+      config
+    );
+
+    expect(params).toMatchSnapshot();
+  });
+
+  it('should return empty extra propose calls if already proven', async () => {
+    mockStorageHash = '0x01';
+
+    const params = await singleSlotProofStrategy.getExtraCalls(
+      'propose',
       '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
       1,
       proposeEnvelope,

--- a/test/unit/strategies/vanilla.test.ts
+++ b/test/unit/strategies/vanilla.test.ts
@@ -27,7 +27,8 @@ describe('vanillaStrategy', () => {
   });
 
   it('should return extra propose calls', async () => {
-    const params = await vanillaStrategy.getExtraProposeCalls(
+    const params = await vanillaStrategy.getExtraCalls(
+      'propose',
       '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
       0,
       proposeEnvelope,


### PR DESCRIPTION
## Summary

Currently we only prove account when proposing, but we should do it also when voting so user can vote on proposals without ever creating a proposal.

Sometimes account is already proven so there is no need to prove it again, this PR also checks if it's needed.

## Test plan

Link this PR on mana and use it on UI:  https://github.com/snapshot-labs/mana/pull/new/sekhmet/upgrade-sx
Create proposal, inspect transaction, it shouldn't have `prove_account` call anymore (if it was already proven).