### PR TITLE
fix(starknet): serialize metadataUri

### DIFF
--- a/src/clients/starknet/space-manager/index.ts
+++ b/src/clients/starknet/space-manager/index.ts
@@ -73,7 +73,7 @@ export class SpaceManager {
         params.executionStrategies.length,
         ...params.executionStrategies,
         metadataUriArr.length,
-        ...metadataUriArr
+        ...metadataUriArr.map(v => `0x${v.toString(16)}`)
       ]
     });
   }


### PR DESCRIPTION
BigInt can't get serialized by ArgentX

Missed this and it won't work in web.