### PR TITLE
fix(evm): add left pad to RSV

### DIFF
--- a/src/authenticators/evm/ethSig.ts
+++ b/src/authenticators/evm/ethSig.ts
@@ -1,5 +1,5 @@
 import EthSigAuthenticatorAbi from './abis/EthSigAuthenticator.json';
-import { getRSVFromSig } from '../../utils/encoding';
+import { getRSVFromSig, hexPadLeft } from '../../utils/encoding';
 import type { Envelope } from '../../clients/evm/types';
 import type { Authenticator, Propose, Vote, EthCall } from '../../types';
 
@@ -16,8 +16,8 @@ export default function createEthSigAuthenticator(): Authenticator<'evm'> {
 
       const args = [
         v,
-        r.toHex(),
-        s.toHex(),
+        hexPadLeft(r.toHex()),
+        hexPadLeft(s.toHex()),
         signatureData.message.salt,
         space,
         selector,


### PR DESCRIPTION
## Summary

`toHex()` can lose padding, we need to padd it for ethers.js.

Closes: https://github.com/snapshot-labs/sx.js/pull/new/sekhmet/hex-pad-rsv

## Test plan

- Run `yarn anvil`
- Run `yarn test:integration:evm` couple times, it always passes.