### PR TITLE
refactor(evm): unify deploySpace call

### DIFF
--- a/test/integration/evm/index.test.ts
+++ b/test/integration/evm/index.test.ts
@@ -23,17 +23,16 @@ describe('EthereumTx', () => {
     ethTxClient = new EthereumTx({ networkConfig: testConfig.networkConfig });
     ethSigClient = new EthereumSig({ networkConfig: testConfig.networkConfig });
 
-    const owner = await signer.getAddress();
+    const controller = await signer.getAddress();
 
-    const res = await ethTxClient.deploy({
+    const res = await ethTxClient.deploySpace({
       signer,
-      spaceFactory: testConfig.spaceFactory,
-      owner,
+      controller,
       votingDelay: 0,
       minVotingDuration: 0,
       maxVotingDuration: 86400,
-      proposalThreshold: 1,
-      quorum: 1,
+      proposalThreshold: 1n,
+      quorum: 1n,
       authenticators: [
         testConfig.vanillaAuthenticator,
         testConfig.ethTxAuthenticator,

--- a/test/integration/evm/utils.ts
+++ b/test/integration/evm/utils.ts
@@ -72,7 +72,7 @@ export async function setup(signer: Signer): Promise<TestConfig> {
     compVotingStrategy,
     executionStrategy,
     networkConfig: {
-      spaceFactory: '0x00',
+      spaceFactory,
       authenticators: {
         [vanillaAuthenticator]: {
           type: 'vanilla'


### PR DESCRIPTION
## Summary

This PR unified deploySpace call a bit more to starknet one (only difference is votingStrategies format).

- rename `deploy` to `deploySpace`.
- use `bigint` for `quorum` and `proposalThreshold`.
- use `spaceFactory` from networkConfig.