### PR TITLE
fix(evm): use getCurrentVotes if stored block is missing

### DIFF
--- a/src/strategies/evm/abis/IComp.json
+++ b/src/strategies/evm/abis/IComp.json
@@ -1,1 +1,4 @@
-["function getPriorVotes(address account, uint256 blockNumber) view returns (uint96)"]
+[
+  "function getCurrentVotes(address account) view returns (uint96)",
+  "function getPriorVotes(address account, uint256 blockNumber) view returns (uint96)"
+]

--- a/src/strategies/evm/comp.ts
+++ b/src/strategies/evm/comp.ts
@@ -17,21 +17,20 @@ export default function createCompStrategy(): Strategy {
       params: string,
       provider: Provider
     ): Promise<bigint> {
+      const compContract = new Contract(params, ICompAbi, provider);
       const votingStrategyContract = new Contract(
         strategyAddress,
         CompVotingStrtategyAbi,
         provider
       );
 
-      let block;
+      let votingPower;
       const storedBlock = await votingStrategyContract.timestampToBlockNumber(timestamp);
-      if (storedBlock.toNumber() > 1) block = storedBlock.toNumber();
-      else {
-        block = (await provider.getBlockNumber()) - 1;
+      if (storedBlock.toNumber() > 1) {
+        votingPower = await compContract.getPriorVotes(voterAddress, storedBlock.toNumber());
+      } else {
+        votingPower = await compContract.getCurrentVotes(voterAddress);
       }
-
-      const compContract = new Contract(params, ICompAbi, provider);
-      const votingPower = await compContract.getPriorVotes(voterAddress, block);
 
       return BigInt(votingPower.toString());
     }

--- a/src/strategies/evm/comp.ts
+++ b/src/strategies/evm/comp.ts
@@ -24,13 +24,10 @@ export default function createCompStrategy(): Strategy {
         provider
       );
 
-      let votingPower;
       const storedBlock = await votingStrategyContract.timestampToBlockNumber(timestamp);
-      if (storedBlock.toNumber() > 1) {
-        votingPower = await compContract.getPriorVotes(voterAddress, storedBlock.toNumber());
-      } else {
-        votingPower = await compContract.getCurrentVotes(voterAddress);
-      }
+      const blockTag = storedBlock.toNumber() > 1 ? storedBlock.toNumber : undefined;
+
+      const votingPower = await compContract.getCurrentVotes(voterAddress, { blockTag });
 
       return BigInt(votingPower.toString());
     }


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx.js/issues/171

getPriorVotes sometimes fail with latest block with error not determined yet.

We can call getCurrentVotes instead, saving one request and preventing those race conditions