### PR TITLE
fix(evm): use correct propser/voter address

### DIFF
--- a/src/clients/evm/ethereum-tx/index.ts
+++ b/src/clients/evm/ethereum-tx/index.ts
@@ -97,7 +97,8 @@ export class EthereumTx {
   }
 
   async propose({ signer, envelope }: { signer: Signer; envelope: Envelope<Propose> }) {
-    const proposerAddress = await signer.getAddress();
+    const proposerAddress = envelope.signatureData?.address || (await signer.getAddress());
+
     const strategiesParams = await getStrategiesParams(
       'propose',
       envelope.data.strategies,
@@ -134,7 +135,8 @@ export class EthereumTx {
   }
 
   async vote({ signer, envelope }: { signer: Signer; envelope: Envelope<Vote> }) {
-    const voterAddress = await signer.getAddress();
+    const voterAddress = envelope.signatureData?.address || (await signer.getAddress());
+
     const strategiesParams = await getStrategiesParams(
       'propose',
       envelope.data.strategies,

--- a/test/integration/evm/index.test.ts
+++ b/test/integration/evm/index.test.ts
@@ -13,6 +13,10 @@ describe('EthereumTx', () => {
     '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
     provider
   );
+  const manaSigner = new Wallet(
+    '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    provider
+  );
 
   let ethTxClient: EthereumTx;
   let ethSigClient: EthereumSig;
@@ -121,7 +125,7 @@ describe('EthereumTx', () => {
       });
 
       const res = await ethTxClient.propose({
-        signer,
+        signer: manaSigner,
         envelope
       });
       expect(res.hash).toBeDefined();
@@ -129,7 +133,7 @@ describe('EthereumTx', () => {
 
     it('should vote via authenticator', async () => {
       const envelope = await ethSigClient.vote({
-        signer,
+        signer: manaSigner,
         data: {
           space: spaceAddress,
           authenticator: testConfig.ethSigAuthenticator,


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx.js/issues/172

Currently Mana sets its own address as voter/proposer, causing those actions to fail, if you are not me.
Now it will read it from signatureData if available.

## Test plan

- Run `yarn anvil`.
- Run `yarn test:integration:evm`.