### PR TITLE
release: v0.1.0-beta.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/sx",
-  "version": "0.1.0-beta.27",
+  "version": "0.1.0-beta.28",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release with `@ethereumjs` packages removed.