### PR TITLE
feat: enable ESM builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 dist
+dist.cjs
 cache
 
 # Remove some common IDE working directories

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@snapshot-labs/sx",
   "version": "0.1.0-beta.44",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist.cjs/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cjs.json",
     "lint:nofix": "eslint ./src ./test --ext .ts",
     "lint": "yarn lint:nofix --fix",
     "prepare": "yarn build",
@@ -56,6 +57,7 @@
   },
   "files": [
     "dist/**/*",
+    "dist.cjs/**/*",
     "src/**/*"
   ]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist.cjs"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node16",
+    "target": "es2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "allowJs": true,
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
If we ship ESM Vite can use this package directly without pre-bundling. This makes Vite reload on changes in this linked package (useful in mono repo, but outside of it as well).