### PR TITLE
chore: set skipLibCheck to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 dist
+dist.cjs
 cache
 
 # Remove some common IDE working directories

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@snapshot-labs/sx",
   "version": "0.1.0-beta.44",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist.cjs/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cjs.json",
     "lint:nofix": "eslint ./src ./test --ext .ts",
     "lint": "yarn lint:nofix --fix",
     "prepare": "yarn build",
@@ -56,6 +57,7 @@
   },
   "files": [
     "dist/**/*",
+    "dist.cjs/**/*",
     "src/**/*"
   ]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist.cjs"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "strict": true,
     "resolveJsonModule": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node16",
+    "target": "es2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "allowJs": true,
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
Depends on https://github.com/snapshot-labs/sx.js/pull/228

This option is not needed currently, but once moved to mono repo we will encounter some broken types from sx-ui (@types/remarkable and @type/inquirer).

Until those are fixed we will need this. I will see if I can resolve those upstream later.