### PR TITLE
fix: user address enum order

### DIFF
--- a/src/utils/starknet-enums.ts
+++ b/src/utils/starknet-enums.ts
@@ -10,8 +10,8 @@ export function getChoiceEnum(choice: 0 | 1 | 2) {
 
 export function getUserAddressEnum(type: 'ETHEREUM' | 'STARKNET' | 'CUSTOM', address: string) {
   return new CairoCustomEnum({
-    Ethereum: type === 'ETHEREUM' ? address : undefined,
     Starknet: type === 'STARKNET' ? address : undefined,
+    Ethereum: type === 'ETHEREUM' ? address : undefined,
     Custom: type === 'CUSTOM' ? address : undefined
   });
 }


### PR DESCRIPTION
the enum variants need to be defined in the same order as in Cairo in order for the encoding to be correct.  Cairo definition: https://github.com/snapshot-labs/sx-starknet/blob/49e42850c808fea30e9fb5da5408478fee7ac680/starknet/src/types/user_address.cairo#L6C1-L6C1