### PR TITLE
chore: define package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "main": "dist.cjs/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist.cjs/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc && tsc -p tsconfig.cjs.json",
     "lint:nofix": "eslint ./src ./test --ext .ts",


### PR DESCRIPTION
`main`/`module` is not standard and not supported anywhere, we should define both for maximum support.