### PR TITLE
fix: use proper start timestamp and chainId

### DIFF
--- a/src/clients/evm/types.ts
+++ b/src/clients/evm/types.ts
@@ -73,7 +73,6 @@ export type Strategy = {
     data: Propose | Vote
   ): Promise<string>;
   getVotingPower(
-    spaceAddress: string,
     strategyAddress: string,
     voterAddress: string,
     metadata: Record<string, any> | null,

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -91,6 +91,7 @@ export const evmLineaGoerli: EvmNetworkConfig = {
 
 export const starknetMainnet: NetworkConfig = {
   eip712ChainId: '0x534e5f4d41494e',
+  herodotusAccumulatesChainId: 1,
   spaceFactory: '0x0250e28c97e729842190c3672f9fcf8db0fc78b8080e87a894831dc69e4f4439',
   masterSpace: '0x00f20287bef9f46c6051e425a84094d2436bcc1fef804db353e60f93661961ac',
   starknetCommit: '0xf1ec7b0276aa5af11ecefe56efb0f198a77016e9',
@@ -123,6 +124,7 @@ export const starknetMainnet: NetworkConfig = {
 
 export const starknetGoerli1: NetworkConfig = {
   eip712ChainId: '0x534e5f474f45524c49',
+  herodotusAccumulatesChainId: 5,
   spaceFactory: '0x063c62258e1ba4d9ad72eab809ea5c3d1a4545b721bc444d6068ced6246c2f3c',
   masterSpace: '0x00f20287bef9f46c6051e425a84094d2436bcc1fef804db353e60f93661961ac',
   starknetCommit: '0x8bf85537c80becba711447f66a9a4452e3575e29',

--- a/src/strategies/evm/comp.ts
+++ b/src/strategies/evm/comp.ts
@@ -10,7 +10,6 @@ export default function createCompStrategy(): Strategy {
       return '0x00';
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,

--- a/src/strategies/evm/merkleWhitelist.ts
+++ b/src/strategies/evm/merkleWhitelist.ts
@@ -38,7 +38,6 @@ export default function createMerkleWhitelist(): Strategy {
       );
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null

--- a/src/strategies/evm/ozVotes.ts
+++ b/src/strategies/evm/ozVotes.ts
@@ -10,7 +10,6 @@ export default function createOzVotesStrategy(): Strategy {
       return '0x00';
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,

--- a/src/strategies/starknet/erc20Votes.ts
+++ b/src/strategies/starknet/erc20Votes.ts
@@ -22,7 +22,6 @@ export default function createErc20VotesStrategy(): Strategy {
       return [];
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,

--- a/src/strategies/starknet/evmSlotValue.ts
+++ b/src/strategies/starknet/evmSlotValue.ts
@@ -108,7 +108,8 @@ export default function createEvmSlotValueStrategy({
       ])) as any;
       const startTimestamp = proposalStruct.start_timestamp;
 
-      const { chainId, contractAddress, slotIndex } = metadata;
+      const { herodotusAccumulatesChainId: chainId } = clientConfig.networkConfig;
+      const { contractAddress, slotIndex } = metadata;
 
       const tree = await getBinaryTree(startTimestamp, chainId);
       const l1BlockNumber = tree.path[1].blockNumber;
@@ -126,7 +127,6 @@ export default function createEvmSlotValueStrategy({
       });
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,
@@ -139,13 +139,10 @@ export default function createEvmSlotValueStrategy({
 
       const contract = new Contract(EVMSlotValue, strategyAddress, clientConfig.starkProvider);
 
-      const spaceContract = new Contract(SpaceAbi, spaceAddress, clientConfig.starkProvider);
-      const proposalStruct = (await spaceContract.call('proposals', [3])) as any;
-      const startTimestamp = proposalStruct.start_timestamp;
+      const { herodotusAccumulatesChainId: chainId } = clientConfig.networkConfig;
+      const { contractAddress, slotIndex } = metadata;
 
-      const { chainId, contractAddress, slotIndex } = metadata;
-
-      const tree = await getBinaryTree(startTimestamp, chainId);
+      const tree = await getBinaryTree(timestamp, chainId);
       const l1BlockNumber = tree.path[1].blockNumber;
 
       const storageProof = await getProof(

--- a/src/strategies/starknet/merkleWhitelist.ts
+++ b/src/strategies/starknet/merkleWhitelist.ts
@@ -42,7 +42,6 @@ export default function createMerkleWhitelistStrategy(): Strategy {
       ];
     },
     async getVotingPower(
-      spaceAddress: string,
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,6 @@ export interface Strategy {
     clientConfig: ClientConfig
   ): Promise<string[]>;
   getVotingPower: (
-    spaceAddress: string,
     strategyAddress: string,
     voterAddress: string,
     metadata: Record<string, any> | null,

--- a/src/types/networkConfig.ts
+++ b/src/types/networkConfig.ts
@@ -56,6 +56,7 @@ export type NetworkConfig = {
   spaceFactory: string;
   masterSpace: string;
   starknetCommit: string;
+  herodotusAccumulatesChainId: number;
   authenticators: {
     [key: string]:
       | VanillaAuthenticatorConfig
@@ -79,7 +80,7 @@ export type NetworkConfig = {
 
 export type EvmNetworkConfig = Omit<
   NetworkConfig,
-  'eip712ChainId' | 'spaceFactory' | 'starknetCommit'
+  'eip712ChainId' | 'spaceFactory' | 'starknetCommit' | 'herodotusAccumulatesChainId'
 > & {
   eip712ChainId: number;
   proxyFactory: string;

--- a/test/unit/strategies/evm/comp.test.ts
+++ b/test/unit/strategies/evm/comp.test.ts
@@ -14,7 +14,6 @@ describe('compStrategy', () => {
   describe('getVotingPower', () => {
     it('should compute voting power for user with delegated tokens at specific timestamp', async () => {
       const votingPower = await compStrategy.getVotingPower(
-        '0x0',
         '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
         null,
@@ -28,7 +27,6 @@ describe('compStrategy', () => {
 
     it('should compute voting power for user without delegated tokens', async () => {
       const votingPower = await compStrategy.getVotingPower(
-        '0x0',
         '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
         '0x000000000000000000000000000000000000dead',
         null,

--- a/test/unit/strategies/evm/ozVotes.test.ts
+++ b/test/unit/strategies/evm/ozVotes.test.ts
@@ -14,7 +14,6 @@ describe('ozVotes', () => {
   describe('getVotingPower', () => {
     it('should compute voting power for user with delegated tokens at specific timestamp', async () => {
       const votingPower = await ozVotesStrategy.getVotingPower(
-        '0x0',
         '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
         '0x537f1896541d28F4c70116EEa602b1B34Da95163',
         null,
@@ -28,7 +27,6 @@ describe('ozVotes', () => {
 
     it('should compute voting power for user without delegated tokens', async () => {
       const votingPower = await ozVotesStrategy.getVotingPower(
-        '0x0',
         '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
         '0x000000000000000000000000000000000000dead',
         null,

--- a/test/unit/strategies/evm/vanilla.test.ts
+++ b/test/unit/strategies/evm/vanilla.test.ts
@@ -13,7 +13,6 @@ describe('vanillaStrategy', () => {
   describe('getVotingPower', () => {
     it('should compute voting power for user', async () => {
       const votingPower = await vanillaStrategy.getVotingPower(
-        '0x0',
         '0x395ed61716b48dc904140b515e9f682e33330154',
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
         null,

--- a/test/unit/strategies/starknet/erc20Votes.test.ts
+++ b/test/unit/strategies/starknet/erc20Votes.test.ts
@@ -46,7 +46,6 @@ describe('erc20VotesStrategy', () => {
 
     it('should compute voting power for user', async () => {
       const votingPower = await erc20VotesStrategy.getVotingPower(
-        '0x0',
         '0x0619040eb54857252396d0bf337dc7a7f98182fa015c11578201105038106cb7',
         '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d',
         null,

--- a/test/unit/strategies/starknet/merkleWhitelist.test.ts
+++ b/test/unit/strategies/starknet/merkleWhitelist.test.ts
@@ -45,7 +45,6 @@ describe('merkleWhitelist', () => {
 
     it('should compute voting power for user', async () => {
       const votingPower = await merkleWhitelist.getVotingPower(
-        '0x0',
         '0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48',
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
         metadata,

--- a/test/unit/strategies/starknet/vanilla.test.ts
+++ b/test/unit/strategies/starknet/vanilla.test.ts
@@ -32,7 +32,6 @@ describe('vanillaStrategy', () => {
 
     it('should compute voting power for user', async () => {
       const votingPower = await vanillaStrategy.getVotingPower(
-        '0x0',
         '0x058623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48',
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
         null,


### PR DESCRIPTION
Changes:
- uses predefined chainId for herodotus (it's no longer part of metadata).
- uses real timestamp instead of reading hardcoded proposal ID (for some reason it got commited like this).