### PR TITLE
feat: accept providedNonce

### DIFF
--- a/src/clients/starknet/starknet-tx/index.ts
+++ b/src/clients/starknet/starknet-tx/index.ts
@@ -167,7 +167,8 @@ export class StarknetTx {
 
     const calls = [call];
 
-    return account.execute(calls, undefined, opts);
+    const fee = await account.estimateFee(calls);
+    return account.execute(calls, undefined, { ...opts, maxFee: fee.suggestedMaxFee });
   }
 
   async updateProposal(account: Account, envelope: Envelope<UpdateProposal>, opts?: Opts) {
@@ -190,7 +191,8 @@ export class StarknetTx {
 
     const calls = [call];
 
-    return account.execute(calls, undefined, opts);
+    const fee = await account.estimateFee(calls);
+    return account.execute(calls, undefined, { ...opts, maxFee: fee.suggestedMaxFee });
   }
 
   async vote(account: Account, envelope: Envelope<Vote>, opts?: Opts) {
@@ -217,7 +219,8 @@ export class StarknetTx {
       metadataUri: ''
     });
 
-    return account.execute(call, undefined, opts);
+    const fee = await account.estimateFee(call);
+    return account.execute(call, undefined, { ...opts, maxFee: fee.suggestedMaxFee });
   }
 
   execute({

--- a/src/clients/starknet/starknet-tx/index.ts
+++ b/src/clients/starknet/starknet-tx/index.ts
@@ -45,6 +45,10 @@ type UpdateSettingsInput = {
   votingStrategyMetadataUrisToAdd?: string[];
 };
 
+type Opts = {
+  nonce?: string;
+};
+
 const NO_UPDATE_U32 = '0xf2cda9b1';
 const NO_UPDATE_ADDRESS = '0xf2cda9b13ed04e585461605c0d6e804933ca828111bd94d4e6a96c75e8b048';
 const NO_UPDATE_STRING = 'No update';
@@ -133,7 +137,7 @@ export class StarknetTx {
     );
   }
 
-  async propose(account: Account, envelope: Envelope<Propose>) {
+  async propose(account: Account, envelope: Envelope<Propose>, opts?: Opts) {
     const authorAddress = envelope.signatureData?.address || account.address;
 
     const authenticator = getAuthenticator(envelope.data.authenticator, this.config.networkConfig);
@@ -163,10 +167,10 @@ export class StarknetTx {
 
     const calls = [call];
 
-    return account.execute(calls);
+    return account.execute(calls, undefined, opts);
   }
 
-  async updateProposal(account: Account, envelope: Envelope<UpdateProposal>) {
+  async updateProposal(account: Account, envelope: Envelope<UpdateProposal>, opts?: Opts) {
     const authorAddress = envelope.signatureData?.address || account.address;
 
     const authenticator = getAuthenticator(envelope.data.authenticator, this.config.networkConfig);
@@ -186,10 +190,10 @@ export class StarknetTx {
 
     const calls = [call];
 
-    return account.execute(calls);
+    return account.execute(calls, undefined, opts);
   }
 
-  async vote(account: Account, envelope: Envelope<Vote>) {
+  async vote(account: Account, envelope: Envelope<Vote>, opts?: Opts) {
     const voterAddress = envelope.signatureData?.address || account.address;
 
     const authenticator = getAuthenticator(envelope.data.authenticator, this.config.networkConfig);
@@ -213,7 +217,7 @@ export class StarknetTx {
       metadataUri: ''
     });
 
-    return account.execute(call);
+    return account.execute(call, undefined, opts);
   }
 
   execute({


### PR DESCRIPTION
This allows us to provide nonce to `propose`/`updateProposal`/`vote` calls. I wanted to use special `Account` type for it, but reverting nonce wasn't really possible with the way `getNonce` is called.

We also have to separate estimateFee call as it won't work with nonces in the future (technically it might be estimating fee at wrong block because of it, but hopefully it doesn't matter that much - we can't do much about it).